### PR TITLE
[WIP] Udpate cachedict for fewer/more flexible files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ ENV/
 exp_local
 outputs
 data
+tmp
 
 # adding output from unit-tests here
 *-raw.fif

--- a/exca/cachedict.py
+++ b/exca/cachedict.py
@@ -259,7 +259,7 @@ class CacheDict(tp.Generic[X]):
                 keyfile.write_text(key, encoding="utf8")
                 files.append(keyfile)
             # new write
-            info = {"key": key, "uid": uid}
+            info: dict[str, tp.Any] = {"key": key, "uid": uid}
             write_fp = self._write_fp
             with write_fp.open("ab") as f:
                 b = json.dumps(info).encode("utf8")

--- a/exca/cachedict.py
+++ b/exca/cachedict.py
@@ -125,7 +125,6 @@ class CacheDict(tp.Generic[X]):
                     sub.unlink()
 
     def __len__(self) -> int:
-        print("in len")
         return len(list(self.keys()))  # inefficient, but correct
 
     def keys(self) -> tp.Iterator[str]:
@@ -164,7 +163,6 @@ class CacheDict(tp.Generic[X]):
             ).decode("utf8")
         except subprocess.CalledProcessError as e:
             out = e.output.decode("utf8")  # stderr contains missing tmp files
-        print("JSON", out)
         names = out.splitlines()
         for name in names:
             lines = (folder / name).read_text().splitlines()

--- a/exca/cachedict.py
+++ b/exca/cachedict.py
@@ -132,13 +132,12 @@ class CacheDict(tp.Generic[X]):
         if self.folder is not None:
             folder = Path(self.folder)
             # read all existing key files as fast as possible (pathlib.glob is slow)
+            find_cmd = 'find . -type f -name "*.key"'
             try:
-                out = subprocess.check_output(
-                    'find . -type f -name "*.key"', shell=True, cwd=folder
-                ).decode("utf8")
+                out = subprocess.check_output(find_cmd, shell=True, cwd=folder)
             except subprocess.CalledProcessError as e:
-                out = e.output.decode("utf8")  # stderr contains missing tmp files
-            names = out.splitlines()
+                out = e.output
+            names = out.decode("utf8").splitlines()
             jobs = {}
             # parallelize content reading
             with futures.ThreadPoolExecutor() as ex:

--- a/exca/cachedict.py
+++ b/exca/cachedict.py
@@ -291,11 +291,13 @@ class CacheDict(tp.Generic[X]):
         info = self._key_info.pop(key)
         keyfile = self.folder / (info["uid"] + ".key")
         keyfile.unlink(missing_ok=True)
-        jsonl = Path(info["_jsonl"])
-        brange = info["_byterange"]
-        with jsonl.open("rb+") as f:
-            f.seek(brange[0])
-            f.write(b" " * (brange[1] - brange[0] - 1) + b"\n")
+        if "_jsonl" in info:
+            jsonl = Path(info["_jsonl"])
+            brange = info["_byterange"]
+            # overwrite with whitespaces
+            with jsonl.open("rb+") as f:
+                f.seek(brange[0])
+                f.write(b" " * (brange[1] - brange[0] - 1) + b"\n")
         dumper = DumperLoader.CLASSES[self.cache_type]()
         fp = dumper.filepath(self.folder / info["uid"])
         with utils.fast_unlink(fp):  # moves then delete to avoid weird effects

--- a/exca/test_cachedict.py
+++ b/exca/test_cachedict.py
@@ -110,8 +110,10 @@ def test_specialized_dump(tmp_path: Path, data: tp.Any, cache_type: str) -> None
     assert isinstance(cache["x"], type(data))
 
 
-@pytest.mark.parametrize("legacy_write", (True, False))
-def test_info_jsonl(tmp_path: Path, legacy_write: bool) -> None:
+@pytest.mark.parametrize(
+    "legacy_write,remove_jsonl", ((True, True), (True, False), (False, False))
+)
+def test_info_jsonl(tmp_path: Path, legacy_write: bool, remove_jsonl: bool) -> None:
     cache: cd.CacheDict[int] = cd.CacheDict(
         folder=tmp_path, keep_in_ram=False, _write_legacy_key_files=legacy_write
     )
@@ -121,11 +123,12 @@ def test_info_jsonl(tmp_path: Path, legacy_write: bool) -> None:
     fps = list(tmp_path.iterdir())
     info_path = [fp for fp in fps if fp.name.endswith("-info.jsonl")][0]
     print(info_path.read_text())
+    if remove_jsonl:
+        info_path.unlink()
     # restore
     cache = cd.CacheDict(folder=tmp_path, keep_in_ram=False)
     assert cache["x"] == 12
     cache = cd.CacheDict(folder=tmp_path, keep_in_ram=False)
     assert "y" in cache
-    print("CHECKING SIZE")
     cache = cd.CacheDict(folder=tmp_path, keep_in_ram=False)
     assert len(cache) == 2

--- a/exca/test_cachedict.py
+++ b/exca/test_cachedict.py
@@ -91,8 +91,6 @@ def test_data_dump_suffix(tmp_path: Path, data: tp.Any) -> None:
     num = len(k_name) - 4
     assert k_name[:num] == k_name[:num], f"Non-matching names {k_name} and {v_name}"
     assert isinstance(cache["blublu.tmp"], type(data))
-    print((tmp_path / j_name).read_text())
-    raise
 
 
 @pytest.mark.parametrize(
@@ -110,3 +108,24 @@ def test_specialized_dump(tmp_path: Path, data: tp.Any, cache_type: str) -> None
     )
     cache["x"] = data
     assert isinstance(cache["x"], type(data))
+
+
+@pytest.mark.parametrize("legacy_write", (True, False))
+def test_info_jsonl(tmp_path: Path, legacy_write: bool) -> None:
+    cache: cd.CacheDict[int] = cd.CacheDict(
+        folder=tmp_path, keep_in_ram=False, _write_legacy_key_files=legacy_write
+    )
+    cache["x"] = 12
+    cache["y"] = 3
+    # check files
+    fps = list(tmp_path.iterdir())
+    info_path = [fp for fp in fps if fp.name.endswith("-info.jsonl")][0]
+    print(info_path.read_text())
+    # restore
+    cache = cd.CacheDict(folder=tmp_path, keep_in_ram=False)
+    assert cache["x"] == 12
+    cache = cd.CacheDict(folder=tmp_path, keep_in_ram=False)
+    assert "y" in cache
+    print("CHECKING SIZE")
+    cache = cd.CacheDict(folder=tmp_path, keep_in_ram=False)
+    assert len(cache) == 2

--- a/exca/test_cachedict.py
+++ b/exca/test_cachedict.py
@@ -83,12 +83,16 @@ def test_data_dump_suffix(tmp_path: Path, data: tp.Any) -> None:
     cache: cd.CacheDict[np.ndarray] = cd.CacheDict(folder=tmp_path, keep_in_ram=False)
     cache["blublu.tmp"] = data
     assert cache.cache_type not in [None, "Pickle"]
-    name1, name2 = [fp.name for fp in tmp_path.iterdir() if not fp.name.startswith(".")]
-    if name2.endswith(".key"):
-        name1, name2 = name2, name1
-    num = len(name1) - 4
-    assert name1[:num] == name2[:num], f"Non-matching names {name1} and {name2}"
+    names = [fp.name for fp in tmp_path.iterdir() if not fp.name.startswith(".")]
+    assert len(names) == 3
+    k_name = [n for n in names if n.endswith(".key")][0]
+    j_name = [n for n in names if n.endswith("-info.jsonl")][0]
+    v_name = [n for n in names if not n.endswith((".key", "-info.jsonl"))][0]
+    num = len(k_name) - 4
+    assert k_name[:num] == k_name[:num], f"Non-matching names {k_name} and {v_name}"
     assert isinstance(cache["blublu.tmp"], type(data))
+    print((tmp_path / j_name).read_text())
+    raise
 
 
 @pytest.mark.parametrize(

--- a/exca/test_cachedict.py
+++ b/exca/test_cachedict.py
@@ -151,14 +151,15 @@ def test_info_jsonl(
 def test_info_jsonl_deletion(
     tmp_path: Path, legacy_write: bool, remove_jsonl: bool
 ) -> None:
-    for k, v in [("x", 12), ("blüblû", 3)]:
-        cache: cd.CacheDict[str] = cd.CacheDict(
+    keys = ("x", "blüblû", "stuff")
+    for k in keys:
+        cache: cd.CacheDict[int] = cd.CacheDict(
             folder=tmp_path, keep_in_ram=False, _write_legacy_key_files=legacy_write
         )
-        cache[k] = v
+        cache[k] = 12 if k == "x" else 3
     _ = cache.keys()  # listing
     info = cache._key_info
-    cache: cd.CacheDict[int] = cd.CacheDict(
+    cache = cd.CacheDict(
         folder=tmp_path, keep_in_ram=False, _write_legacy_key_files=legacy_write
     )
     _ = cache.keys()  # listing
@@ -170,12 +171,17 @@ def test_info_jsonl_deletion(
             f.seek(r[0])
             out = f.read(r[1] - r[0])
             assert out.startswith(b"{") and out.endswith(b"}\n")
-            print(out)
+    if remove_jsonl:
+        for ipath in tmp_path.glob("*.jsonl"):
+            ipath.unlink()
+        cache = cd.CacheDict(
+            folder=tmp_path, keep_in_ram=False, _write_legacy_key_files=legacy_write
+        )
     # remove one
-    chosen = np.random.choice(["x", "blüblû"])
+    chosen = np.random.choice(keys)
     del cache[chosen]
-    assert len(cache) == 1
-    cache: cd.CacheDict[int] = cd.CacheDict(
+    assert len(cache) == 2
+    cache = cd.CacheDict(
         folder=tmp_path, keep_in_ram=False, _write_legacy_key_files=legacy_write
     )
-    assert len(cache) == 1
+    assert len(cache) == 2

--- a/exca/test_cachedict.py
+++ b/exca/test_cachedict.py
@@ -92,6 +92,7 @@ def test_data_dump_suffix(tmp_path: Path, data: tp.Any) -> None:
     num = len(k_name) - 4
     assert k_name[:num] == k_name[:num], f"Non-matching names {k_name} and {v_name}"
     assert isinstance(cache["blublu.tmp"], type(data))
+    assert (tmp_path / j_name).read_text().startswith("{")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Use a single file per thread to store information about stored elements:
- 2x fewer files
- more flexibility with stored information (ability to pack numpy arrays into one memmap eventually)