### PR TITLE
Adding support for brainvision format

### DIFF
--- a/exca/dumperloader.py
+++ b/exca/dumperloader.py
@@ -153,20 +153,16 @@ except ImportError:
 else:
 
     Raw = mne.io.Raw | RawBrainVision
-    mne_ch_types = tp.Literal[
-        "eeg", "seeg", "ecog", "mag", "grad", "ref_meg"
-    ]  # XXX Actually a lot more of these, see mne/_fiff/meas_info.py
+    meg_channel_types = ("mag", "grad", "ref_meg")
 
     class MneRaw(DumperLoader[Raw]):
-        """Use .fif format for MEG channel types (mag, grad and ref_meg), otherwise use BrainVision format."""
+        """Use .fif format for MEG channel types, otherwise use BrainVision format."""
 
         SUFFIXES: list[str] = ["-raw.fif", "-raw.vhdr"]
 
         @staticmethod
-        def _get_suffix(
-            ch_types: list[mne_ch_types],
-        ) -> tp.Literal["-raw.fif", "-raw.vhdr"]:
-            if any(ch_type in ["mag", "grad", "ref_meg"] for ch_type in ch_types):
+        def _get_suffix(ch_types: list[str]) -> tp.Literal["-raw.fif", "-raw.vhdr"]:
+            if any(ch_type in meg_channel_types for ch_type in ch_types):
                 return "-raw.fif"
             return "-raw.vhdr"
 
@@ -212,7 +208,9 @@ except ImportError:
     pass
 else:
 
-    Nifti = nibabel.Nifti1Image | nibabel.Nifti2Image | nibabel.filebasedimages.FileBasedImage
+    Nifti = (
+        nibabel.Nifti1Image | nibabel.Nifti2Image | nibabel.filebasedimages.FileBasedImage
+    )
 
     class NibabelNifti(DumperLoader[Nifti]):
         SUFFIX = ".nii.gz"

--- a/exca/dumperloader.py
+++ b/exca/dumperloader.py
@@ -174,6 +174,7 @@ else:
     DumperLoader.DEFAULTS[(mne.io.Raw, mne.io.RawArray)] = MneRawFif
     DumperLoader.CLASSES["MneRaw"] = MneRawFif  # for backwards compatibility
 
+
 try:
     # pylint: disable=unused-import
     import mne

--- a/exca/test_dumperloader.py
+++ b/exca/test_dumperloader.py
@@ -32,6 +32,7 @@ def make_mne_raw(ch_type: str) -> mne.io.RawArray:
         nib.Nifti1Image(np.ones(5), np.eye(4)),
         nib.Nifti2Image(np.ones(5), np.eye(4)),
         pd.DataFrame([{"blu": 12}]),
+        make_mne_raw("eeg"),
         "stuff",
     ),
 )
@@ -44,6 +45,8 @@ def test_data_dump_suffix(tmp_path: Path, data: tp.Any) -> None:
     dl.dump(tmp_path / "blublu.ext", data)
     reloaded = dl.load(tmp_path / "blublu.ext")
     ExpectedCls = type(data)
+    if ExpectedCls is mne.io.RawArray:
+        ExpectedCls = mne.io.Raw
     assert isinstance(reloaded, ExpectedCls)
 
 
@@ -74,6 +77,9 @@ def test_mne_raw(tmp_path: Path, ch_type: str, name: str) -> None:
         else mne.io.brainvision.brainvision.RawBrainVision
     )
     assert isinstance(reloaded, reload_type)
+    raw_data = raw.get_data()
+    reloaded_data = reloaded.get_data()
+    assert np.allclose(raw_data, reloaded_data, atol=1e-8)
 
 
 def test_mne_raw_brainvision_backwards_comp(tmp_path: Path) -> None:

--- a/exca/test_dumperloader.py
+++ b/exca/test_dumperloader.py
@@ -18,7 +18,7 @@ from . import dumperloader
 
 
 def make_meeg(
-    ch_type: tp.Literal["eeg", "ecog", "seeg", "mag", "grad"]
+    ch_type: tp.Literal["eeg", "ecog", "seeg", "mag", "grad", "ref_meg"]
 ) -> mne.io.RawArray:
     n_channels, sfreq, duration = 4, 64, 60
     data = np.random.rand(n_channels, sfreq * duration)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
         "pandas>=2.2.2",
         "torch>=2.0.1",
         "mne>=1.4.0",
+        "pybv>=0.7.6",
         "nibabel>=5.1.0",
         "pyarrow>=17.0.0",
         # Test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ skip_gitignore = true
   show_error_codes = true
 
 [[tool.mypy.overrides]]
-  module = ['pytest', 'setuptools', 'cloudpickle', 'mne', 'nibabel', 'neuralset', 'pyarrow']
+  module = ['pytest', 'setuptools', 'cloudpickle', 'mne', 'mne.*', 'nibabel', 'neuralset', 'pyarrow', 'pybv']
   ignore_missing_imports = true
 [[tool.mypy.overrides]]
   # some packages we do not install


### PR DESCRIPTION
This PR adds support for dumping/loading `mne.io.Raw` objects using the BrainVision file format. As we still need to cache MEG data using .fif, the approach I took here is to identify the channel types before dumping, and to do some trial/error when loading.

TODO:
- [x] Review file format selection logic at dumping and loading time @kingjr 
- [x] Organize the multiple files (.eeg, .vhdr, .vmrk) into a single directory per item
- [x] Handle float64 warning when dumping to BrainVision format