### PR TITLE
Create `ConfDict` using json-mode model dump

### DIFF
--- a/exca/test_utils.py
+++ b/exca/test_utils.py
@@ -415,3 +415,4 @@ y: PT1M
 z: exca.confdict.ConfDict
 """
     assert out.to_yaml() == expected
+    assert out.to_uid().startswith("x=-,y=PT1M,z=exca.confdict.ConfDict")

--- a/exca/test_utils.py
+++ b/exca/test_utils.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+import datetime
 import os
 import typing as tp
 from pathlib import Path
@@ -397,3 +398,20 @@ def test_fast_unlink(tmp_path: Path) -> None:
     with utils.fast_unlink(fp):
         pass
     assert not fp.exists()
+
+
+class ComplexTypesConfig(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="forbid")
+    x: pydantic.DirectoryPath = Path("/")
+    y: datetime.timedelta = datetime.timedelta(minutes=1)
+    z: pydantic.ImportString = ConfDict
+
+
+def test_complex_types() -> None:
+    c = ComplexTypesConfig()
+    out = ConfDict.from_model(c, uid=True, exclude_defaults=False)
+    expected = """x: /
+y: PT1M
+z: exca.confdict.ConfDict
+"""
+    assert out.to_yaml() == expected

--- a/exca/utils.py
+++ b/exca/utils.py
@@ -94,7 +94,7 @@ def to_dict(
     if exclude_defaults:
         _set_discriminated_status(model)
     cfg = ExportCfg(uid=uid, exclude_defaults=exclude_defaults)
-    out = model.model_dump(exclude_defaults=exclude_defaults)
+    out = model.model_dump(exclude_defaults=exclude_defaults, mode="json")
     if uid or exclude_defaults:
         _apply_dump_tags(model, out, cfg=cfg)
     return out


### PR DESCRIPTION
Hi @jrapin @kingjr,

Super cool library :D 

I was playing a bit, but my model had some non-simple types (like `date time.timedelta` or `pydantic.ImportString`) that are not compatible with `exec.ConfDict`' s `to_yaml` and `to_uid` methods.

See, before fix:
```
exca/test_utils.py:417: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
exca/confdict.py:200: in to_yaml
    out: str = _yaml.safe_dump(_to_simplified_dict(self), sort_keys=True)
../../miniforge3/envs/exca/lib/python3.10/site-packages/yaml/__init__.py:269: in safe_dump
    return dump_all([data], stream, Dumper=SafeDumper, **kwds)
../../miniforge3/envs/exca/lib/python3.10/site-packages/yaml/__init__.py:241: in dump_all
    dumper.represent(data)
../../miniforge3/envs/exca/lib/python3.10/site-packages/yaml/representer.py:27: in represent
    node = self.represent_data(data)
../../miniforge3/envs/exca/lib/python3.10/site-packages/yaml/representer.py:48: in represent_data
    node = self.yaml_representers[data_types[0]](self, data)
../../miniforge3/envs/exca/lib/python3.10/site-packages/yaml/representer.py:207: in represent_dict
    return self.represent_mapping('tag:yaml.org,2002:map', data)
../../miniforge3/envs/exca/lib/python3.10/site-packages/yaml/representer.py:118: in represent_mapping
    node_value = self.represent_data(item_value)
../../miniforge3/envs/exca/lib/python3.10/site-packages/yaml/representer.py:58: in represent_data
    node = self.yaml_representers[None](self, data)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <yaml.dumper.SafeDumper object at 0x157555030>
data = datetime.timedelta(seconds=60)

    def represent_undefined(self, data):
>       raise RepresenterError("cannot represent an object", data)
E       yaml.representer.RepresenterError: ('cannot represent an object', datetime.timedelta(seconds=60))

../../miniforge3/envs/exca/lib/python3.10/site-packages/yaml/representer.py:231: RepresenterError
```

This PR sets `model_dump(..., mode="json")`, which uses pydantic's logic to convert many types to JSON-compatible ones.

All the current tests pass. Could this change cause issues at non-tested places?