### PR TITLE
Change min_samples_per_job from 2048 to 1

### DIFF
--- a/exca/map.py
+++ b/exca/map.py
@@ -179,7 +179,7 @@ class MapInfra(base.BaseInfra, slurm.SubmititMixin):
     keep_in_ram: bool = True
     # job configuration
     max_jobs: int | None = 128
-    min_samples_per_job: int = 2048
+    min_samples_per_job: int = 1
     forbid_single_item_computation: bool = False  # for local/slurm/auto
     cluster: tp.Literal[None, "auto", "local", "slurm", "debug", "threadpool", "processpool"] = None  # type: ignore
     # mode among:


### PR DESCRIPTION
Reason for this change: many people don't know about this parameter, although it is absolutely essential to leverage the power of a cluster. I don't think it's dangerous to set it to a low value by default, since the number of jobs is capped by max_jobs anyway. Having this second knob doesn't seem useful except in very specific usecases