### PR TITLE
Add codespell support with configuration and fixes

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,9 @@ repos:
     hooks:
       - id: nbstripout
         language_version: python3
+  
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in .pre-commit-config.yaml
+    rev: v2.4.1
+    hooks:
+    - id: codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,9 @@ repos:
         language_version: python3
   
   - repo: https://github.com/codespell-project/codespell
-    # Configuration for codespell is in .pre-commit-config.yaml
+    # Configuration for codespell is in pyproject.toml
     rev: v2.4.1
     hooks:
     - id: codespell
+      additional_dependencies:
+      - tomli; python_version<'3.11'

--- a/docs/infra/explanation.md
+++ b/docs/infra/explanation.md
@@ -45,7 +45,7 @@ Pydantic hierarchical configuration and discriminated unions allows for modulari
 
 `TaskInfra` must be applied to a method with no parameter (except `self`). It links 1 computation to 1 job and therefore provides easy tools for accessing the job stdout/stderr/status etc.
 
-`MapInfra` on the other hand must be applied to a method with 1 parameter (in addition to `self`) which must be a `m`-sized iterator/sequence of items. It requires stating how to provide a unique uid for each item (throught the `item_uid` function, and it maps `m` computation (1 for each item) to `n <= m` jobs, packing several computations together. Because of this non-bijective mapping, there is no support for checking jobs stderr/stdout/status.
+`MapInfra` on the other hand must be applied to a method with 1 parameter (in addition to `self`) which must be a `m`-sized iterator/sequence of items. It requires stating how to provide a unique uid for each item (through the `item_uid` function, and it maps `m` computation (1 for each item) to `n <= m` jobs, packing several computations together. Because of this non-bijective mapping, there is no support for checking jobs stderr/stdout/status.
 
 
 ## uid computation
@@ -54,7 +54,7 @@ A unique id, the `uid`, is computed for each pydantic model/each config based on
 - which are non-defaults
 - which are not excluded through the `_exclude_from_cls_uid` class attribute list/tuple 
   (or class method returning a list/tuple). This allows removing parameters which do not impact 
-  the result (eg: number of workers, device, ect...). 
+  the result (eg: number of workers, device, etc...). 
 
 *Note*: `infra` objects have all their parameters excluded except `version` as the parameters affects how the computation
 is performed but not the result
@@ -65,7 +65,7 @@ to post-process the cached computation). This is done by specifying `exclude_fro
 `infra.apply` method. This cache uid is used as storage folder name for the cache.
 Exclusion can be specified as a list/tuple of field, or as a method, or as the name of a method 
 (with format `method:<method_name>`). Notice that when subclassing, if you specified the exclusion
-as a function, the original function will be used (not the new function if it was overriden), 
+as a function, the original function will be used (not the new function if it was overridden), 
 if you want to use the new one, then you should specify the method through its name.
 
 See more in the [example](howto-efficient-caching) from the how-to guide.

--- a/docs/infra/howto.md
+++ b/docs/infra/howto.md
@@ -219,12 +219,12 @@ household = Household(pet={"name": "dog"})
 assert household.pet.dog_param == 12
 ```
 
-The syntax requires providing a "discriminator" field which is a constant (a `Literal`) for selecting which class to instantiate. While explicitely stating the discriminator through `pydantic.Field` (as above) or through an annotation (see in `pydantic` documentation) is not strictly necessary with `pydantic`, it is necessary when working with infras so that the discriminator be part of the uid.
+The syntax requires providing a "discriminator" field which is a constant (a `Literal`) for selecting which class to instantiate. While explicitly stating the discriminator through `pydantic.Field` (as above) or through an annotation (see in `pydantic` documentation) is not strictly necessary with `pydantic`, it is necessary when working with infras so that the discriminator be part of the uid.
 
 
 ## Workdir/code copy
 
-Running code on a cluster while still working on the code can be dangereous, as the job will use the state of the code **at start time** and **not at submission time**.
+Running code on a cluster while still working on the code can be dangerous, as the job will use the state of the code **at start time** and **not at submission time**.
 
 In order to avoid surprises, both task/map infra support a `workdir` for copying the code to a different working directory where the decorated function will be running from:
 [Check its parameters here](exca.workdir.WorkDir), in particular, the `copied` parameter can be used to select folders or files or packages installed in editable mode that should be copied to the job's working directory, like in the [`TutorialTask` class from the tutorial section](infra/tutorials:TaskInfra):

--- a/docs/infra/introduction.md
+++ b/docs/infra/introduction.md
@@ -1,6 +1,6 @@
 # Exca - Execution and caching
 
-This is an explanation to why `exca` was built. If you are only intereseted in how to use it, you can move to [tutorials](tutorials.md) and [how-to](howto.md) pages.
+This is an explanation to why `exca` was built. If you are only interested in how to use it, you can move to [tutorials](tutorials.md) and [how-to](howto.md) pages.
 
 Here are the challenges we want to face:
 1. config validation and remote computation
@@ -52,7 +52,7 @@ mytask = MyTask(x=12)
 mytask.x  # this is 12
 
 # MyTask(x="blublu")  
-# >> ValidationError: 1 validation error for MyTask (x hould be a valid integer)
+# >> ValidationError: 1 validation error for MyTask (x should be a valid integer)
 ```
 
 Pydantic supports hierarchical configurations:
@@ -268,7 +268,7 @@ Discriminated unions make it easier to make **modular pipelines** as one can swa
 
 ## Challenge #3: Experiment/computation caching
 
-`exca` can also handle **caching of the computation result** with no extra effort, so any computation already performed will only be recomputed if explicitely required.
+`exca` can also handle **caching of the computation result** with no extra effort, so any computation already performed will only be recomputed if explicitly required.
 
 A lot of additional benefits also come for free:
 - sub-configs can have their own infra.

--- a/docs/infra/tutorials.md
+++ b/docs/infra/tutorials.md
@@ -153,7 +153,7 @@ out2 = my_func(a=3, b=4)
 np.testing.assert_array_equal(out2, out)  # should the same (as cached)
 ```
 
-On the long run this is not adviced as this will prevent you from using many features of infra (running an array of jobs, checking their status etc)
+On the long run this is not advised as this will prevent you from using many features of infra (running an array of jobs, checking their status etc)
 
 
 ## Pydantic models

--- a/docs/internal/steps/chain_step_duality.md
+++ b/docs/internal/steps/chain_step_duality.md
@@ -64,14 +64,14 @@ class ChainMixin:
     ...
 
 class NeuralChain(ChainMixin, NeuralStep):
-    steps: list[NeuralStep] | ...  # must re-declare (mixin can't own the field)
+    steps: list[NeuralStep] | ...  # must redeclare (mixin can't own the field)
 ```
 
 **Pros**: no diamond, no `# type: ignore`, more extensible (any class can mix
 in chain behavior).
 
 **Cons**: bigger refactor (~200 lines moved), breaks `isinstance(x, Chain)` for
-downstream chains, requires re-declaring `steps` on every chain subclass, and
+downstream chains, requires redeclaring `steps` on every chain subclass, and
 downstream code must migrate.
 
 **Decision**: `_exca_chain_class` is non-breaking and solves the immediate

--- a/exca/base.py
+++ b/exca/base.py
@@ -159,7 +159,7 @@ class BaseInfra(pydantic.BaseModel):
     def __setstate__(self, state: tp.Any) -> None:
         if "__dict__" in state:
             d = state["__dict__"]
-            # compatiblity
+            # compatibility
             d.setdefault("version", "0")
             d.setdefault("mode", "cached")
         if "__pydantic_private__" in state:
@@ -274,7 +274,7 @@ class BaseInfra(pydantic.BaseModel):
         if isinstance(self._infra_method, InfraMethod):  # NOT LEGACY
             m = self._infra_method.method
             factory = f"{m.__module__}.{m.__qualname__}"
-            # if the method is not overriden, then use the current class name
+            # if the method is not overridden, then use the current class name
             current_m = getattr(cls, m.__name__)
             if isinstance(current_m, property) and self._infra_method is current_m.fget:
                 factory = f"{cls.__module__}.{cls.__qualname__}.{name}"
@@ -388,7 +388,7 @@ class BaseInfra(pydantic.BaseModel):
         cdict = self.config(exclude_defaults=True, uid=False)
         cdict.update(kwargs)
         out = self._obj.model_validate(cdict)
-        _ = self.uid()  # trigger uid computation (to propagate dicriminated status)
+        _ = self.uid()  # trigger uid computation (to propagate discriminated status)
         try:
             utils.copy_discriminated_status(self._obj, out)
         except Exception as e:
@@ -468,7 +468,7 @@ class BaseInfraMethod:
 
     def __post_init__(self) -> None:
         if self.method.__name__.startswith("__"):
-            raise ValueError("Private methods cannot be overriden")
+            raise ValueError("Private methods cannot be overridden")
         functools.update_wrapper(self, self.method)  # type: ignore
         if isinstance(self.exclude_from_cache_uid, str):
             if not self.exclude_from_cache_uid.startswith("method:"):
@@ -504,10 +504,10 @@ class InfraMethod(BaseInfraMethod):
             # recheck if infra is available (this may have been skipped for hidden infra)
             _add_name(obj, propagate_defaults=False)
             if self.infra_name is None:
-                self.infra_name = ""  # not found = overriden by another infra instance
+                self.infra_name = ""  # not found = overridden by another infra instance
         infra_name = self.infra_name
         if not infra_name:
-            # bypassing infra as it was overriden
+            # bypassing infra as it was overridden
             return functools.partial(self.method, obj)
         if not isinstance(obj, pydantic.BaseModel):
             raise TypeError("infra can only be added to pydantic.BaseModel")
@@ -530,7 +530,7 @@ class InfraMethod(BaseInfraMethod):
         if "_obj" not in (infra.__pydantic_private__ or {}):
             infra._obj = obj  # only for legacy to decorator change compatibility
         if default_imethod is not self:
-            # bypassing infra as it was overriden
+            # bypassing infra as it was overridden
             return functools.partial(self.method, obj)
         result = infra._method_override
         state = _fast_state(infra)

--- a/exca/cachedict/core.py
+++ b/exca/cachedict/core.py
@@ -322,7 +322,7 @@ class CacheDict(tp.Generic[X]):
         if self._folder_modified <= 0:
             _ = self.keys()
         if key in self._ram_data or key in self._key_info:
-            raise ValueError(f"Overwritting a key is currently not implemented ({key=})")
+            raise ValueError(f"Overwriting a key is currently not implemented ({key=})")
         if self._keep_in_ram and self.folder is None:
             self._ram_data[key] = value
         if self.folder is not None:

--- a/exca/cachedict/test_registry.py
+++ b/exca/cachedict/test_registry.py
@@ -43,7 +43,7 @@ def test_context_manager(tmp_path: Path) -> None:
     with errors.ErrorRegistry(tmp_path) as reg:
         reg.record(["a"])
         assert reg.get(["a"]) == {"a"}
-    # Re-using after __exit__ silently reconnects (lazy semantics).
+    # Reusing after __exit__ silently reconnects (lazy semantics).
     assert reg.get(["a"]) == {"a"}
     reg.close()
 

--- a/exca/confdict.py
+++ b/exca/confdict.py
@@ -92,7 +92,7 @@ class ConfDict(dict[str, tp.Any]):
 
     Example
     -------
-    :code:`ConDict({"training.optim.lr": 0.01}) == {"training": {"optim": {"lr": 0.01}}}`
+    :code:`ConfDict({"training.optim.lr": 0.01}) == {"training": {"optim": {"lr": 0.01}}}`
 
     Note
     ----
@@ -234,7 +234,7 @@ class ConfDict(dict[str, tp.Any]):
 
     def to_yaml(self, filepath: Path | str | None = None) -> str:
         """Exports the ConfDict to yaml string
-        and optionnaly to a file if a filepath is provided
+        and optionally to a file if a filepath is provided
         """
         out: str = _yaml.safe_dump(_to_simplified_dict(self), sort_keys=True)
         if filepath is not None:

--- a/exca/helpers.py
+++ b/exca/helpers.py
@@ -206,7 +206,7 @@ class InfraSlurmJob(submitit.SlurmJob[tp.Any]):
 def find_slurm_job(
     *, job_id: str, folder: str | Path | None = None
 ) -> InfraSlurmJob | None:
-    r"""Attemps to instantiate a submitit.SlurmJob instance from a cache folder and a `job_id`,
+    r"""Attempts to instantiate a submitit.SlurmJob instance from a cache folder and a `job_id`,
     looking for it recursively.
     This is based on default configuration of the log folder position
     (:code:`<cache folder>/logs/<username>/<job_id>`), and some additional heuristic that may be

--- a/exca/map.py
+++ b/exca/map.py
@@ -245,7 +245,7 @@ class MapInfra(base.BaseInfra, slurm.SubmititMixin):
             - :code:`NumpyArray`:  stores numpy arrays as npy files (default for np.ndarray)
             - :code:`NumpyMemmapArray`: similar to NumpyArray but reloads arrays as memmaps
             - :code:`MemmapArrayFile`: stores multiple np.ndarray into a unique memmap file
-              (strongly adviced in case of many arrays)
+              (strongly advised in case of many arrays)
             - :code:`PandasDataFrame`: stores pandas dataframes as csv (default for dataframes)
             - :code:`ParquetPandasDataFrame`: stores pandas dataframes as parquet files
             - :code:`TorchTensor`: stores torch.Tensor as .pt file (default for tensors)
@@ -566,6 +566,6 @@ class MapInfraMethod(base.InfraMethod):
             collections.abc.Sequence,
         ]:
             raise TypeError(
-                "Decorated method single argument should be annnotated as List, Tuple, Sequence or Iterable "
+                "Decorated method single argument should be annotated as List, Tuple, Sequence or Iterable "
                 f"(got {origin} from {param!r})"
             )

--- a/exca/slurm.py
+++ b/exca/slurm.py
@@ -79,7 +79,7 @@ class SubmititMixin(pydantic.BaseModel):
     slurm_partition: optional str
         partition for the slurm job
     slurm_use_srun: bool
-        use srun in the sbatch file. This is the default in submitit, but not adviced
+        use srun in the sbatch file. This is the default in submitit, but not advised
         for jobs triggering more jobs.
     slurm_additional_parameters: optional dict
         additional parameters for slurm that are not first class parameters of this config

--- a/exca/task.py
+++ b/exca/task.py
@@ -527,7 +527,7 @@ class SubmitInfra(base.BaseInfra, slurm.SubmititMixin):
     _array_executor: submitit.Executor | None = pydantic.PrivateAttr(None)
 
     def _exclude_from_cls_uid(self) -> list[str]:
-        return ["."]  # not taken into accound for uid
+        return ["."]  # not taken into account for uid
 
     # pylint: disable=unused-argument
     def apply(self, method: base.C) -> base.C:
@@ -549,7 +549,7 @@ class SubmitInfra(base.BaseInfra, slurm.SubmititMixin):
         return property(self._infra_method)  # type: ignore
 
     def submit(self, *args: tp.Any, **kwargs: tp.Any) -> submitit.Job[tp.Any] | LocalJob:
-        """Submit an asynchroneous job. This call is non-blocking and returns a
+        """Submit an asynchronous job. This call is non-blocking and returns a
         :code:`Job` instance that has a :code:`result()` method that awaits
         for the computation to be over.
 

--- a/exca/test_base.py
+++ b/exca/test_base.py
@@ -138,8 +138,8 @@ def test_subclass_infra_func_raw(tmp_path: Path) -> None:
     "cls,name",
     [
         (Base, "Base.func,12"),
-        (SubFunc, "Base.func,12"),  # function is overriden
-        (SubInfra2Func, "Base.func,12"),  # function is overriden
+        (SubFunc, "Base.func,12"),  # function is overridden
+        (SubInfra2Func, "Base.func,12"),  # function is overridden
         (SubBase, "SubBase.func,12"),  # function is the same -> get new class
     ],
 )

--- a/exca/test_safeguard.py
+++ b/exca/test_safeguard.py
@@ -51,7 +51,7 @@ def test_read_text_encoding() -> None:
     if found:
         found_str = "\n - ".join(found)
         msg = f"Following files contain read_text() without encoding:\n - {found_str}"
-        # this is dangereous as it will depend on local settings
+        # this is dangerous as it will depend on local settings
         raise AssertionError(msg)
 
 
@@ -86,7 +86,7 @@ def test_header() -> None:
 
 
 if __name__ == "__main__":
-    # run this test independantly to make sure only base exca is loaded
+    # run this test independently to make sure only base exca is loaded
     _: tp.Any = exca.MapInfra()
     _ = exca.TaskInfra()
     modules = ["torch", "mne", "pandas", "nibabel"]  # numpy is loaded

--- a/exca/test_task.py
+++ b/exca/test_task.py
@@ -391,7 +391,7 @@ def test_mode_with_array(tmp_path: Path) -> None:
     params = {"infra.cluster": "local", "infra.mode": "force"}
     with cfg.infra.job_array() as tasks:
         tasks.extend([c.infra.clone_obj(params) for c in cfgs])
-        # t.infra.mode is actually unecessary cos using cfg.infra.mode
+        # t.infra.mode is actually unnecessary cos using cfg.infra.mode
         assert all(t.infra.mode == "force" for t in tasks)
     out2 = [c.process() for c in tasks]
     for a1, a2 in zip(out, out2):

--- a/exca/test_utils.py
+++ b/exca/test_utils.py
@@ -355,7 +355,7 @@ class NewDefaultOther2diff(BaseModel):
 
 
 def test_new_default_other2diff() -> None:
-    # revert unneeded to default, so it wont show in model_dump, but we need to define x=13
+    # revert unneeded to default, so it won't show in model_dump, but we need to define x=13
     m = NewDefaultOther2diff(a={"x": 13, "unneeded": "is default"})  # type: ignore
     out = ConfDict.from_model(m, uid=True, exclude_defaults=True)
     assert out.to_yaml().strip() == "a.x: 13"

--- a/exca/utils.py
+++ b/exca/utils.py
@@ -112,7 +112,7 @@ class ConfigExporter(pydantic.BaseModel):
             )
             excluded = info[UID_EXCLUDED]
             forced = info[FORCE_INCLUDED]
-            excluded -= forced  # forced taks over
+            excluded -= forced  # forced takes over
             fields = set(type(obj).model_fields)
             missing = (excluded | forced) - (fields | {"."})
 
@@ -156,7 +156,7 @@ class ConfigExporter(pydantic.BaseModel):
                     continue
                 if not (cfg.exclude_defaults and cfg.uid):
                     continue
-                # possibly remove if all default (appart from excluded attributes)
+                # possibly remove if all default (apart from excluded attributes)
                 if not isinstance(obj[name], pydantic.BaseModel):
                     continue
                 if not isinstance(bobj, pydantic.BaseModel):
@@ -339,7 +339,7 @@ def _set_discriminated_status(
         name = f"{cls.__module__}.{cls.__qualname__}"
         msg = f"It is strongly advised to forbid extra parameters to {name} by adding to its def:\n"
         msg += 'model_config = pydantic.ConfigDict(extra="forbid")\n'
-        msg += '(you can however bypass this error by explicitely setting extra="allow")'
+        msg += '(you can however bypass this error by explicitly setting extra="allow")'
         raise RuntimeError(msg)
     # propagate below
     schema: tp.Any = None
@@ -534,7 +534,7 @@ def temporary_save_path(filepath: Path | str, replace: bool = True) -> tp.Iterat
         yield tmppath
     except Exception:
         if tmppath.exists():
-            msg = "Exception occured, clearing temporary save file %s"
+            msg = "Exception occurred, clearing temporary save file %s"
             logger.warning(msg, tmppath)
             os.remove(tmppath)
         raise

--- a/exca/workdir.py
+++ b/exca/workdir.py
@@ -73,7 +73,7 @@ class WorkDir(pydantic.BaseModel):
         file/folder name pattern than mush be excluded
     log_commit: bool
         if True, raises if current working directory is in a git repository
-        with uncommited changes and logs commit otherwise
+        with uncommitted changes and logs commit otherwise
 
     Notes
     -----
@@ -81,7 +81,7 @@ class WorkDir(pydantic.BaseModel):
       the copied packages should be the one running in the job
       (be careful there can be a few gotchas, eg: for debug cluster or with no cluster,
       the import cannot be not reloaded so the current working directory will be used,
-      but that should not make a difference in theses cases)
+      but that should not make a difference in these cases)
     - The change of working directory (and possibly the copy) only happens when the
       infra is called for submitting the decorated function. Depending on your code,
       this may not be at the very beginning of your execution.
@@ -120,7 +120,7 @@ class WorkDir(pydantic.BaseModel):
                 name = Path(folder.decode("utf8").strip()).name
                 if name in self._commits:
                     continue
-                # check commited
+                # check committed
                 subprocess.check_call(["git", "diff", "--exit-code"], shell=False, cwd=p)
                 # get git hash
                 cmd = ["git", "rev-parse", "--short", "HEAD"]
@@ -218,7 +218,7 @@ class Ignore:
         missing = set(names) - included
         path = Path(path)
         for excluded in missing:
-            # always include subfolders except if explicitely excluded below
+            # always include subfolders except if explicitly excluded below
             if (path / excluded).is_dir():
                 included.add(excluded)
         for exclude in self.excludes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,3 +126,10 @@ addopts = ["--ignore=build", "--ignore=dist"]
   init_forbid_extra = true
   init_typed = true
   warn_required_dynamic_aliases = true
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git,.gitignore,.gitattributes,*.css'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ addopts = ["--ignore=build", "--ignore=dist"]
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git,.gitignore,.gitattributes,*.css,*.pkl,*.svg,*.pdf,*.min.*'
+skip = '.git,.git-meta,.gitignore,.gitattributes,*.css,*.pkl,*.svg,*.pdf,*.min.*'
 check-hidden = true
 # ignore-regex = ''
 # expec: variable name (short for "expected") used in tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,9 @@ addopts = ["--ignore=build", "--ignore=dist"]
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git,.gitignore,.gitattributes,*.css'
+skip = '.git,.gitignore,.gitattributes,*.css,*.pkl,*.svg,*.pdf,*.min.*'
 check-hidden = true
 # ignore-regex = ''
-# ignore-words-list = ''
+# expec: variable name (short for "expected") used in tests
+# tring: intentional substring in elided uid hash test fixtures (string=... truncated)
+ignore-words-list = 'expec,tring'


### PR DESCRIPTION
Add codespell configuration and fix existing typos.

More about codespell: https://github.com/codespell-project/codespell

I personally introduced it to over a hundred of projects already mostly with a positive feedback (see the ["improveit-dashboard"](https://github.com/yarikoptic/improveit-dashboard/blob/master/READMEs/yarikoptic.md)).

CI workflow has `permissions` set only to `read` so it should be safe.

## Changes

### Configuration & Infrastructure
- Added `[tool.codespell]` section in `pyproject.toml`
- Created `.github/workflows/codespell.yml` to check spelling on push and PRs to `main`
- Added codespell hook to `.pre-commit-config.yaml` (with `tomli` additional_dependency for pyproject.toml support on Python <3.11)
- Configured `skip` to exclude binary/data files: `*.pkl`, `*.svg`, `*.pdf`, `*.min.*`, `*.css`
- Configured `check-hidden = true` so dotfiles are scanned

### Domain-Specific Whitelist
Added legitimate terms via `ignore-words-list = expec,tring`:
- `expec` — variable name (short for "expected") used in `exca/test_confdict.py`
- `tring` — intentional substring inside elided uid hash test fixtures (e.g. `"...num=12345678[.]tring=abcdefghij..."` where `string=` was truncated)

### Typo Fixes

**Ambiguous typos fixed manually** (5 fixes with context review — `codespell -w` skips these because they have multiple suggestions):
- `ConDict` → `ConfDict` (`exca/confdict.py:95`) — class name typo in docstring example; the actual class is `ConfDict`, not `conduct`/`convict`
- `throught` → `through` (`docs/infra/explanation.md:48`) — preposition, not "thought"/"throughout"
- `hould` → `should` (`docs/infra/introduction.md:55`) — inside a quoted ValidationError message, not "hold"
- `taks` → `takes` (`exca/utils.py:115`) — comment "forced takes over" describing precedence, not "task"/"tasks"
- `theses` → `these` (`exca/workdir.py:84`) — "in these cases", not "thesis"

**Non-ambiguous typos fixed automatically via `codespell -w`** (~50 fixes across 19 files):
Common fixes include: `overriden` → `overridden` (×8), `explicitely` → `explicitly` (×4), `adviced` → `advised` (×3), `dangereous` → `dangerous` (×2), `commited`/`uncommited` → `committed`/`uncommitted`, `compatiblity` → `compatibility`, `occured` → `occurred`, `optionnaly` → `optionally`, `unecessary` → `unnecessary`, `intereseted` → `interested`, `appart` → `apart`, `wont` → `won't`, `dicriminated` → `discriminated`, `asynchroneous` → `asynchronous`, `Overwritting` → `Overwriting`, `Attemps` → `Attempts`, `Re-using` → `Reusing`, `re-declare`/`re-declaring` → `redeclare`/`redeclaring`, `accound` → `account`, `annnotated` → `annotated`, `ect` → `etc`, `independantly` → `independently`.

### Historical Context
This project has had at least 3 prior commits manually fixing typos (`5f00902`, `cdf1ff0`, `747ff86`), demonstrating the value of automated spell-checking on push/PRs.

## Testing

✅ `codespell` passes with zero errors after all fixes
✅ `pre-commit run --all-files` passes (ruff, ruff-format, nbstripout, codespell)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) and love to typos free code
