### PR TITLE
[Step] Support named Chain step indexing

### DIFF
--- a/exca/steps/base.py
+++ b/exca/steps/base.py
@@ -469,12 +469,19 @@ class Chain(Step):
     def __getitem__(self, index: int) -> Step: ...
 
     @tp.overload
+    def __getitem__(self, index: str) -> Step: ...
+
+    @tp.overload
     def __getitem__(self, index: slice) -> "Chain": ...
 
-    def __getitem__(self, index: int | slice) -> Step | Chain:
+    def __getitem__(self, index: int | str | slice) -> Step | Chain:
         steps = self._step_sequence()
         if isinstance(index, int):
             return steps[index]
+        if isinstance(index, str):
+            if isinstance(self.steps, dict):
+                return self.steps[index]
+            raise TypeError("String indices require Chain.steps to be an OrderedDict")
         if isinstance(index, slice):
             sliced = steps[index]
             if isinstance(self.steps, dict):

--- a/exca/steps/test_steps.py
+++ b/exca/steps/test_steps.py
@@ -477,6 +477,18 @@ def test_chain_indexing() -> None:
         chain[10]
 
 
+def test_chain_string_indexing() -> None:
+    steps = collections.OrderedDict(
+        add=conftest.Add(value=1),
+        mult=conftest.Mult(coeff=2),
+    )
+    chain = Chain(steps=steps)
+    assert chain["add"].model_dump() == steps["add"].model_dump()
+    assert chain["mult"].model_dump() == steps["mult"].model_dump()
+    with pytest.raises(KeyError):
+        chain["missing"]
+
+
 def test_chain_slicing(tmp_path: Path) -> None:
     steps = [conftest.Add(value=1), conftest.Mult(coeff=2), conftest.Add(value=3)]
     chain = Chain(steps=steps)


### PR DESCRIPTION
## Summary
- Allow `Chain` instances with ordered mapping steps to access children via `chain["name"]`.
- Preserve existing integer indexing and slicing behavior.
- Add a focused regression test for named step lookup and missing keys.

## Test plan
- `python -m pytest exca/steps/test_steps.py -q`


Made with [Cursor](https://cursor.com)