### PR TITLE
chore: declare contents: read on test-type-lint workflow

### DIFF
--- a/.github/workflows/test-type-lint.yaml
+++ b/.github/workflows/test-type-lint.yaml
@@ -4,6 +4,9 @@ env:
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   run-on-ubuntu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
test-type-lint runs the test suite with mypy + linters. `codespell.yml` already declares workflow-level `contents: read`; matching that style for the remaining CI workflow.