### PR TITLE
Add Hdf5DataArray handler for xarray.DataArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - `exca/steps`: update experimental batch execution API to `step.run_many([v1, v2, ...])`. [#275]
+- `exca/cachedict`: `Hdf5DataArray` handler stores `xarray.DataArray` as netCDF/HDF5 (`cache_type="Hdf5DataArray"`).
 
 ## 0.5.26 - 26-06-03
 

--- a/exca/cachedict/handlers.py
+++ b/exca/cachedict/handlers.py
@@ -313,6 +313,35 @@ class MneRawBrainVision:
             shutil.rmtree(dirpath)
 
 
+@DumpContext.register
+class Hdf5DataArray(KeyFileHandler):
+    """Stores an ``xarray.DataArray`` as one netCDF/HDF5 file (h5netcdf engine),
+    round-tripping the array name (an unnamed array reloads with ``name=None``)."""
+
+    @classmethod
+    def __dump_info__(cls, ctx: DumpContext, value: tp.Any) -> dict[str, tp.Any]:
+        import xarray as xr
+
+        if not isinstance(value, xr.DataArray):
+            raise TypeError(f"Only supports xr.DataArray (got {type(value)})")
+        named = value.name is not None
+        if not named:
+            value = value.rename("value")  # to_netcdf requires a named variable
+        name = ctx.key_path(".h5")
+        with utils.temporary_save_path(ctx.folder / name) as tmp:
+            value.to_netcdf(tmp, engine="h5netcdf")
+        return {"filename": name, "named": named}
+
+    @classmethod
+    def __load_from_info__(
+        cls, ctx: DumpContext, filename: str, named: bool = True
+    ) -> tp.Any:
+        import xarray as xr
+
+        da = xr.open_dataarray(ctx.folder / filename, engine="h5netcdf").load()
+        return da if named else da.rename(None)
+
+
 # =============================================================================
 # Auto (universal handler, replaces DataDict)
 # =============================================================================

--- a/exca/cachedict/test_dumpcontext.py
+++ b/exca/cachedict/test_dumpcontext.py
@@ -210,6 +210,27 @@ def test_key_path_concurrent_write_tolerance(tmp_path: Path) -> None:
     assert ctx2.load(info2) == 99
 
 
+def test_hdf5_dataarray_roundtrip(tmp_path: Path) -> None:
+    xr = pytest.importorskip("xarray")
+    pytest.importorskip("h5netcdf")
+    da = xr.DataArray(
+        np.arange(6.0).reshape(2, 3),
+        dims=("subject", "time"),
+        coords={"subject": [1, 2], "time": [0.1, 0.2, 0.3]},
+        name="score",
+    )
+    ctx = DumpContext(tmp_path, key="named")
+    with ctx:
+        info = ctx.dump(da, cache_type="Hdf5DataArray")
+    assert info["#type"] == "Hdf5DataArray"
+    xr.testing.assert_identical(ctx.load(info), da)
+    # an unnamed array round-trips with its name restored to None
+    ctx = DumpContext(tmp_path, key="unnamed")
+    with ctx:
+        info = ctx.dump(da.rename(None), cache_type="Hdf5DataArray")
+    assert ctx.load(info).name is None
+
+
 # =============================================================================
 # Json
 # =============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
         "pyarrow>=17.0.0",
         "xarray>=2024.1.0",
         "h5netcdf>=1.3.0",
+        "h5py>=3.0.0",  # h5netcdf write backend used by the Hdf5DataArray handler
         # Test
         "pytest>=7.4.0",
         "pytest-markdown-docs>=0.5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
         "pybv>=0.7.6",
         "nibabel>=5.1.0",
         "pyarrow>=17.0.0",
+        "xarray>=2024.1.0",
+        "h5netcdf>=1.3.0",
         # Test
         "pytest>=7.4.0",
         "pytest-markdown-docs>=0.5.0",
@@ -115,7 +117,7 @@ addopts = ["--ignore=build", "--ignore=dist"]
   show_error_codes = true
 
 [[tool.mypy.overrides]]
-  module = ['pytest', 'setuptools', 'cloudpickle', 'mne', 'mne.*', 'nibabel', 'neuralset', 'pyarrow', 'pybv', 'excatest']
+  module = ['pytest', 'setuptools', 'cloudpickle', 'mne', 'mne.*', 'nibabel', 'neuralset', 'pyarrow', 'pybv', 'xarray', 'excatest']
   ignore_missing_imports = true
 [[tool.mypy.overrides]]
   # some packages we do not install


### PR DESCRIPTION
## Summary

Adds an opt-in cache handler that serializes an `xarray.DataArray` to a single netCDF/HDF5 file via the `h5netcdf` engine, instead of pickling.

```python
ctx.dump(data_array, cache_type="Hdf5DataArray")   # -> .h5 file
# or, on a Step:  CACHE_TYPE = "Hdf5DataArray"
```

- Mirrors the existing optional-library handlers (`NibabelNifti`, `MneRawFif`): a `KeyFileHandler` registered by name with no `default_for`, so xarray stays an optional dependency (lazy import inside the methods).
- Round-trips the array name; an unnamed array reloads with `name=None`.
- `xarray` + `h5netcdf` added to the `dev` extras; `xarray` added to the mypy ignore-missing-imports list.

## Test plan

- [x] `pytest exca/cachedict/test_dumpcontext.py` (incl. new `test_hdf5_dataarray_roundtrip`)
- [x] `ruff format --check` + `ruff check`
- [x] `mypy exca/cachedict/handlers.py` (clean for the new handler)

Made with [Cursor](https://cursor.com)