### PR TITLE
Compact repr for infra objects (#289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Infra reprs now only display fields that differ from their default value. [#289]
 - `exca/steps`: `Scatter` primitive — fan each input into N branches, run a body Step per branch, gather (N->NxM->N). [#282]
 - `exca/steps`: update experimental batch execution API to `step.run_many([v1, v2, ...])`. [#275]
 

--- a/exca/base.py
+++ b/exca/base.py
@@ -200,17 +200,8 @@ class BaseInfra(pydantic.BaseModel):
 
     def __repr_args__(self) -> tp.Iterator[tuple[str | None, tp.Any]]:
         """Compact repr: only show fields that differ from their default value."""
-        # note: fields with a default_factory have default=PydanticUndefined,
-        # so they never compare equal and are always shown
-        fields = type(self).model_fields
-        for name, value in super().__repr_args__():
-            if name is not None and name in fields:
-                try:
-                    if bool(value == fields[name].default):
-                        continue  # equal to default -> hide
-                except Exception:
-                    pass  # non-comparable values are shown
-            yield name, value
+        for name in self.model_dump(exclude_defaults=True):
+            yield name, getattr(self, name)
 
     def config(self, uid: bool = True, exclude_defaults: bool = False) -> ConfDict:
         """Exports the task configuration as a ConfigDict

--- a/exca/base.py
+++ b/exca/base.py
@@ -198,6 +198,20 @@ class BaseInfra(pydantic.BaseModel):
         super().model_post_init(log__)
         self._set_permissions(None)  # set compatibility for permissions as string
 
+    def __repr_args__(self) -> tp.Iterator[tuple[str | None, tp.Any]]:
+        """Compact repr: only show fields that differ from their default value."""
+        # note: fields with a default_factory have default=PydanticUndefined,
+        # so they never compare equal and are always shown
+        fields = type(self).model_fields
+        for name, value in super().__repr_args__():
+            if name is not None and name in fields:
+                try:
+                    if bool(value == fields[name].default):
+                        continue  # equal to default -> hide
+                except Exception:
+                    pass  # non-comparable values are shown
+            yield name, value
+
     def config(self, uid: bool = True, exclude_defaults: bool = False) -> ConfDict:
         """Exports the task configuration as a ConfigDict
         ConfDict are dict which split on "." with extra flatten,

--- a/exca/test_base.py
+++ b/exca/test_base.py
@@ -609,6 +609,17 @@ if __name__ == "__main__":
         assert list(Path(tmp).iterdir())
 
 
+def test_repr_shows_only_non_defaults() -> None:
+    infra = TaskInfra(folder="/tmp/blublu", version="3")
+    rep = repr(infra)
+    assert rep == "TaskInfra(folder='/tmp/blublu', version='3')"
+    # fields equal to their default are hidden even when explicitly set
+    assert repr(TaskInfra(mode="cached")) == "TaskInfra()"
+    # non-default values coming from a class-level default remain visible
+    model = Base(infra={"folder": "/tmp/blublu"})  # type: ignore
+    assert "version='12'" in repr(model.infra)
+
+
 def test_fast_state_no_fallback() -> None:
     """Catch pydantic upgrades that change PrivateAttr storage."""
     model = Base(param=1)


### PR DESCRIPTION

First contribution to exca — happy to adjust anything. Thanks for the quick feedback @kingjr

---

Closes: https://github.com/facebookresearch/exca/issues/289

---

Override pydantic's __repr_args__ on BaseInfra so that repr only displays fields that differ from their default value, per maintainer feedback on #289. Cache uids, config(), pickling and equality are untouched.

## Before the change

```python
import tempfile
import numpy as np
import pydantic
import exca

class TutorialTask(pydantic.BaseModel):
    param: int = 12
    infra: exca.TaskInfra = exca.TaskInfra(version="1")

    @infra.apply
    def process(self) -> float:
        return self.param * np.random.rand()

with tempfile.TemporaryDirectory() as tmpdir:
    task = TutorialTask(param=1, infra={"folder": tmpdir})
    out = task.process()
    assert out == task.process()
```

Prints one long line with all ~25 fields.

```python
task
# TutorialTask(param=1, infra=TaskInfra(folder='/tmp/tmp8upyg51q', cluster=None, logs='{folder}/logs/{user}/%j', job_name=None, timeout_min=None, nodes=1, tasks_per_node=1, cpus_per_task=None, gpus_per_node=None, mem_gb=None, max_pickle_size_gb=None, slurm_constraint=None, slurm_partition=None, slurm_account=None, slurm_qos=None, slurm_use_srun=False, slurm_additional_parameters=None, slurm_setup=None, conda_env=None, workdir=None, permissions=511, version='1', mode='cached', keep_in_ram=False))
```

## After the change

Install code in this PR instead and restart the Python kernel.

```bash
pip install -q --force-reinstall --no-deps git+https://github.com/bkowshik/exca.git@compact-infra-repr > /dev/null 2>&1
```

Now, it prints only non-default fields.

```python
task
# TutorialTask(param=1, infra=TaskInfra(folder='/tmp/tmpxxksa0eh', version='1'))
```

## Discoverability note

The repr no longer lists every available field — it answers _"what did I change"_, not _"what could I change"_. For the latter, `TaskInfra.model_fields` and the `__init__` signature (IDE/Jupyter autocomplete) all still show the full set.