### PR TITLE
Improve DB updates

### DIFF
--- a/exca/cachedict/inflight.py
+++ b/exca/cachedict/inflight.py
@@ -280,10 +280,12 @@ class InflightRegistry(registry.AdvisoryRegistry):
             return
 
         def _do(conn: sqlite3.Connection) -> None:
+            conn.execute("BEGIN")
             conn.executemany(
                 "UPDATE inflight SET job_id = ?, job_folder = ? WHERE item_uid = ?",
                 [(job_id, job_folder, uid) for uid in item_uids],
             )
+            conn.execute("COMMIT")
 
         self._safe_execute("update", None, _do)
         msg = "Updated worker info for %d items (job_id=%s)"

--- a/exca/cachedict/registry.py
+++ b/exca/cachedict/registry.py
@@ -106,7 +106,7 @@ class AdvisoryRegistry:
             timeout=20,
             isolation_level=None,
         )
-        conn.execute("PRAGMA journal_mode=DELETE")
+        conn.execute("PRAGMA journal_mode=WAL")
         conn.executescript(self._SCHEMA)
         if self.permissions is not None:
             try:


### PR DESCRIPTION
`update_worker_info()` used autocommit, creating one transaction—and associated NFS journal/lock/fsync work—per item. Under large updates this could freeze. This PR wraps the batch in one transaction and enables WAL to further reduce rollback-journal contention.

edit: the WAL update should not have been added since it is unsuitable for the actual multi-host NFS deployment.