### PR TITLE
Add ConfDict operations + Preserve ConfDict order in yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- `ConfDict`: added `ConfDict` operations `ConfDict.ops.DELETE`, `ConfDict.ops.BEFORE`, and `ConfDict.ops.AFTER`; `ConfDict.ops.REPLACE` replaces `ConfDict.OVERRIDE`. [#310]
+- Config YAML dumps now preserve key order, cache uid checks tolerates key-order-only `uid.yaml` changes for compatibility. [#310]
+
 ## 0.5.28 - 26-07-20
 
 - `steps`: reduced `run_many` overhead by reusing warm cache-backed carriers in composed chains and fusing consecutive inline per-item steps. [#306, #307]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 - `ConfDict`: added `ConfDict` operations `ConfDict.ops.DELETE`, `ConfDict.ops.BEFORE`, and `ConfDict.ops.AFTER`; `ConfDict.ops.REPLACE` replaces `ConfDict.OVERRIDE`. [#310]
-- Config YAML dumps now preserve key order, cache uid checks tolerates key-order-only `uid.yaml` changes for compatibility. [#310]
+- Config YAML dumps now preserve key order, cache uid checks tolerate key-order-only `uid.yaml` changes for compatibility. [#310]
 - `ConfDict`: `pop`/`del` no longer prune emptied parent mappings; an empty mapping is a value like any other. [#311]
 
 ## 0.5.28 - 26-07-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 - `ConfDict`: added `ConfDict` operations `ConfDict.ops.DELETE`, `ConfDict.ops.BEFORE`, and `ConfDict.ops.AFTER`; `ConfDict.ops.REPLACE` replaces `ConfDict.OVERRIDE`. [#310]
-- Config YAML dumps now preserve key order, cache uid checks tolerate key-order-only `uid.yaml` changes for compatibility. [#310]
+- Config YAML dumps now preserve key order; cache uid checks tolerate key-order-only `uid.yaml` changes for compatibility. [#310]
 - `ConfDict`: `pop`/`del` no longer prune emptied parent mappings; an empty mapping is a value like any other. [#311]
 
 ## 0.5.28 - 26-07-20

--- a/exca/confdict.py
+++ b/exca/confdict.py
@@ -43,7 +43,9 @@ class ConfDictOps:
         if not isinstance(value, str) or cls._PATTERN.fullmatch(value) is None:
             return False
         if value not in {cls.REPLACE, cls.DELETE, cls.BEFORE, cls.AFTER}:
-            raise ValueError(f"Unknown ConfDict op {value!r}")
+            msg = f"Unknown ConfDict op {value!r} (key or values with format "
+            msg += "'=<string>=' are reserved for operations)"
+            raise ValueError(msg)
         return True
 
 
@@ -181,7 +183,7 @@ class ConfDict(dict[str, tp.Any], metaclass=_ConfDictMeta):
     ----
     - This is designed for configurations, so it probably does not scale well to 100k+ keys
     - Updates apply patches: mappings that merge dict values recursively and
-      may contain operation tokens. See :code:`ConfDict.update`.
+      may contain operation tokens. See :code:`ConfDict.update`..
     """
 
     LATEST_UID_VERSION = 3

--- a/exca/confdict.py
+++ b/exca/confdict.py
@@ -148,10 +148,17 @@ def _set_item(obj: tp.Any, key: str, val: tp.Any) -> None:
     ConfDict.ops.is_op(p)  # reject op-shaped typos used as keys
     if isinstance(val, dict) and not isinstance(val, OrderedDict):
         sub = obj[p]
-        if not isinstance(sub, ConfDict):
+        if isinstance(sub, OrderedDict):
+            patched = ConfDict(sub)
+            patched.update(val)
+            sub.clear()
+            sub.update(OrderedDict(patched.items()))
+        elif not isinstance(sub, ConfDict):
             sub = ConfDict(sub) if isinstance(sub, dict) else ConfDict()
             dict.__setitem__(obj, p, sub)
-        sub.update(val)
+            sub.update(val)
+        else:
+            sub.update(val)
         _apply_move(obj, p)
     else:
         dict.__setitem__(obj, p, val)

--- a/exca/confdict.py
+++ b/exca/confdict.py
@@ -131,14 +131,6 @@ def _set_item(obj: tp.Any, key: str, val: tp.Any) -> None:
             else:
                 dict.__setitem__(obj, p, sub)
         _set_item(sub, rest[0], val)
-        if (
-            existed
-            and val == ConfDict.ops.DELETE
-            and isinstance(obj, dict)
-            and isinstance(sub, dict)
-            and not sub
-        ):
-            dict.pop(obj, p, None)
         return
     # final part
     val = _propagate_confdict(val, replace_dicts=False)

--- a/exca/confdict.py
+++ b/exca/confdict.py
@@ -13,6 +13,7 @@ import os
 import re
 import sys
 import typing as tp
+import warnings
 from collections import OrderedDict, abc
 from pathlib import Path, PosixPath, WindowsPath
 
@@ -27,22 +28,54 @@ Mapping = tp.MutableMapping[str, tp.Any] | tp.Iterable[tuple[str, tp.Any]]
 _sentinel = object()
 
 
+class ConfDictOps:
+    _PATTERN = re.compile(r"=.+=")
+    REPLACE = "=replace="
+    DELETE = "=delete="
+    BEFORE = "=before="
+    AFTER = "=after="
+
+    @classmethod
+    def is_op(cls, value: tp.Any) -> tp.TypeGuard[str]:
+        if not isinstance(value, str) or cls._PATTERN.fullmatch(value) is None:
+            return False
+        if value not in {cls.REPLACE, cls.DELETE, cls.BEFORE, cls.AFTER}:
+            raise ValueError(f"Unknown ConfDict op {value!r}")
+        return True
+
+
+class _ConfDictMeta(type):
+    @property
+    def OVERRIDE(cls) -> str:  # noqa: N802
+        warnings.warn(
+            "ConfDict.OVERRIDE is deprecated, use ConfDict.ops.REPLACE",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return ConfDictOps.REPLACE
+
+
 def _is_seq(val: tp.Any) -> tp.TypeGuard[tp.Sequence[tp.Any]]:
     return isinstance(val, abc.Sequence) and not isinstance(val, str)
 
 
-def _propagate_confdict(obj: tp.Any, replace_dicts: bool = False) -> tp.Any:
+def _propagate_confdict(
+    obj: tp.Any, replace_dicts: bool = False, *, apply_ops: bool
+) -> tp.Any:
     """Recursively cast content of list and ordered dict to to confdicts"""
-    # Note: avoid replacing native dicts as they may contain ConfDict.OVERRIDE tag
+    # Note: avoid replacing native dicts as they may contain ConfDict.ops.REPLACE tag
     # which needs to be processed later on
+    params = dict(replace_dicts=True, apply_ops=apply_ops)
     if isinstance(obj, OrderedDict):
-        sub = {x: _propagate_confdict(y, replace_dicts=True) for x, y in obj.items()}
+        sub = {x: _propagate_confdict(y, **params) for x, y in obj.items()}
         return OrderedDict(sub)
     if replace_dicts and isinstance(obj, dict):
-        return ConfDict(obj)
+        sub = ConfDict()
+        sub._update(obj, apply_ops=apply_ops)
+        return sub
     if _is_seq(obj):
         Container = obj.__class__
-        return Container([_propagate_confdict(v, replace_dicts=True) for v in obj])  # type: ignore
+        return Container([_propagate_confdict(v, **params) for v in obj])  # type: ignore
     if isinstance(obj, dict):
         return obj
     if isinstance(obj, ConfDict):
@@ -55,7 +88,7 @@ def _move_key(
 ) -> None:
     if before is not None and after is not None:
         raise ValueError(
-            f"Use either {ConfDict.BEFORE!r} or {ConfDict.AFTER!r}, not both"
+            f"Use either {ConfDict.ops.BEFORE!r} or {ConfDict.ops.AFTER!r}, not both"
         )
     anchor = before if before is not None else after
     if anchor is None:
@@ -75,27 +108,35 @@ def _move_key(
             obj[key] = value
 
 
-def _update_mapping(obj: dict[str, tp.Any], key: str, val: dict[str, tp.Any]) -> None:
+def _update_mapping(
+    obj: dict[str, tp.Any], key: str, val: dict[str, tp.Any], *, apply_ops: bool
+) -> None:
     val = dict(val)
     before: str | None = None
     after: str | None = None
-    if ConfDict.BEFORE in val:
-        before = val.pop(ConfDict.BEFORE)
+    if apply_ops and ConfDict.ops.BEFORE in val:
+        before = val.pop(ConfDict.ops.BEFORE)
         if not isinstance(before, str):
-            raise TypeError(f"{ConfDict.BEFORE!r} expects a key name, got {before!r}")
-    if ConfDict.AFTER in val:
-        after = val.pop(ConfDict.AFTER)
+            raise TypeError(f"{ConfDict.ops.BEFORE!r} expects a key name, got {before!r}")
+    if apply_ops and ConfDict.ops.AFTER in val:
+        after = val.pop(ConfDict.ops.AFTER)
         if not isinstance(after, str):
-            raise TypeError(f"{ConfDict.AFTER!r} expects a key name, got {after!r}")
+            raise TypeError(f"{ConfDict.ops.AFTER!r} expects a key name, got {after!r}")
     if val:
-        if isinstance(obj[key], dict):
-            obj[key].update(val)
+        if isinstance(obj[key], ConfDict):
+            sub = obj[key]
+        elif isinstance(obj[key], dict):
+            sub = ConfDict()
+            sub._update(obj[key], apply_ops=apply_ops)
+            dict.__setitem__(obj, key, sub)
         else:
-            dict.__setitem__(obj, key, ConfDict(val))
+            sub = ConfDict()
+            dict.__setitem__(obj, key, sub)
+        sub._update(val, apply_ops=apply_ops)
     _move_key(obj, key, before=before, after=after)
 
 
-def _set_item(obj: tp.Any, key: str, val: tp.Any) -> None:
+def _set_item(obj: tp.Any, key: str, val: tp.Any, *, apply_ops: bool) -> None:
     """Internal recursive setitem on ConfDict/list"""
     p, *rest = key.split(".", maxsplit=1)
     if isinstance(obj, dict):
@@ -113,9 +154,10 @@ def _set_item(obj: tp.Any, key: str, val: tp.Any) -> None:
                 obj[p] = sub  # type: ignore
             else:
                 dict.__setitem__(obj, p, sub)
-        _set_item(sub, rest[0], val)
+        _set_item(sub, rest[0], val, apply_ops=apply_ops)
         if (
-            val == ConfDict.DELETE
+            apply_ops
+            and val == ConfDict.ops.DELETE
             and isinstance(obj, dict)
             and isinstance(sub, dict)
             and not sub
@@ -123,23 +165,27 @@ def _set_item(obj: tp.Any, key: str, val: tp.Any) -> None:
             dict.pop(obj, p, None)
         return
     # final part
-    val = _propagate_confdict(val, replace_dicts=False)
-    if val == ConfDict.DELETE:
+    val = _propagate_confdict(val, replace_dicts=False, apply_ops=apply_ops)
+    if apply_ops and val == ConfDict.ops.DELETE:
         if _is_seq(obj):
             raise TypeError(f"Cannot delete key {p!r} on existing sequence {obj!r}")
         dict.pop(obj, p, None)
         return
+    if apply_ops and ConfDict.ops.is_op(val):
+        raise ValueError(f"Unexpected ConfDict op value {val!r}")
     # list case
     if _is_seq(obj):
         obj[p] = val  # type: ignore
         return
+    if apply_ops and ConfDict.ops.is_op(p):
+        raise ValueError(f"Unexpected ConfDict op key {p!r}")
     if isinstance(val, dict) and not isinstance(val, OrderedDict):
-        _update_mapping(obj, p, val)
+        _update_mapping(obj, p, val, apply_ops=apply_ops)
     else:
         dict.__setitem__(obj, p, val)
 
 
-class ConfDict(dict[str, tp.Any]):
+class ConfDict(dict[str, tp.Any], metaclass=_ConfDictMeta):
     """Dictionary which breaks into sub-dictionnaries on "." as in a config (see example)
     The data can be specified either through "." keywords or directly through sub-dicts
     or a mixture of both.
@@ -153,22 +199,20 @@ class ConfDict(dict[str, tp.Any]):
     Note
     ----
     - This is designed for configurations, so it probably does not scale well to 100k+ keys
-    - dicts are merged except if containing the key :code:`ConfDict.OVERRIDE`,
+    - dicts are merged except if containing the key :code:`ConfDict.ops.REPLACE`,
       in which case they replace the content. The scalar value
-      :code:`ConfDict.DELETE` deletes a key. The keys :code:`ConfDict.BEFORE`
-      and :code:`ConfDict.AFTER` move a key within the containing mapping.
+      :code:`ConfDict.ops.DELETE` deletes a key. The keys
+      :code:`ConfDict.ops.BEFORE` and :code:`ConfDict.ops.AFTER` move a key
+      within the containing mapping.
     """
 
     LATEST_UID_VERSION = 3
     UID_VERSION = int(os.environ.get("CONFDICT_UID_VERSION", LATEST_UID_VERSION))
-    OVERRIDE = "=replace="
-    DELETE = "=delete="
-    BEFORE = "=before="
-    AFTER = "=after="
+    ops = ConfDictOps
 
     def __init__(self, mapping: Mapping | None = None, **kwargs: tp.Any) -> None:
         super().__init__()
-        self.update(mapping, **kwargs)
+        self._update(mapping, apply_ops=True, **kwargs)
 
     @classmethod
     def from_model(
@@ -199,7 +243,7 @@ class ConfDict(dict[str, tp.Any]):
     def __setitem__(self, key: str, val: tp.Any) -> None:
         if not isinstance(key, str):
             raise TypeError(f"ConfDict only supports str keys, got {key!r}")
-        _set_item(self, key, val)
+        _set_item(self, key, val, apply_ops=True)
 
     def __getitem__(self, key: str) -> tp.Any:
         parts = key.split(".")
@@ -249,20 +293,41 @@ class ConfDict(dict[str, tp.Any]):
     def update(  # type: ignore
         self, mapping: Mapping | None = None, **kwargs: tp.Any
     ) -> None:
-        """Updates recursively the keys of the confdict.
-        No key is removed unless a sub-dictionary contains :code:`"=replace=": True`,
-        in this case the existing keys in the sub-dictionary are wiped
+        """Recursively update the config.
+
+        Dicts merge by default. :code:`ConfDict.ops.REPLACE` replaces a mapping,
+        :code:`ConfDict.ops.DELETE` removes a key, and
+        :code:`ConfDict.ops.BEFORE` / :code:`ConfDict.ops.AFTER` move a key.
+
+        Example
+        -------
+        .. code-block:: python
+
+            cfg = ConfDict({"a": {"x": 1}, "b": {"x": 2}})
+
+            cfg.update({"a": {ConfDict.ops.REPLACE: True, "y": 4}, "b": {"y": 12}})
+            >> {"a": {"y": 4}, "b": {"x": 2, "y": 12}}
+
+            cfg.update({"a": {ConfDict.ops.AFTER: "b"}, "b.x": ConfDict.ops.DELETE})
+            >> {"b": {"y": 12}, "a": {"y": 4}}
         """
+        self._update(mapping, apply_ops=True, **kwargs)
+
+    def _update(
+        self, mapping: Mapping | None = None, *, apply_ops: bool, **kwargs: tp.Any
+    ) -> None:
         if mapping is not None:
             if not isinstance(mapping, abc.Mapping):
                 mapping = dict(mapping)
             kwargs.update(mapping)
         if not kwargs:
             return
-        if kwargs.pop(ConfDict.OVERRIDE, False):
+        if apply_ops and kwargs.pop(ConfDict.ops.REPLACE, False):
             self.clear()
         for key, val in kwargs.items():
-            self[key] = val
+            if not isinstance(key, str):
+                raise TypeError(f"ConfDict only supports str keys, got {key!r}")
+            _set_item(self, key, val, apply_ops=apply_ops)
 
     def flat(self) -> dict[str, tp.Any]:
         """Returns a flat dictionary such as
@@ -274,7 +339,12 @@ class ConfDict(dict[str, tp.Any]):
         return self.__class__(super().copy())
 
     @classmethod
-    def from_yaml(cls, yaml: str | Path | tp.IO[str] | tp.IO[bytes]) -> "ConfDict":
+    def from_yaml(
+        cls,
+        yaml: str | Path | tp.IO[str] | tp.IO[bytes],
+        *,
+        apply_ops: bool = True,
+    ) -> "ConfDict":
         """Loads a ConfDict from a yaml string/filepath/file handle."""
         input_ = yaml
         if isinstance(yaml, str):
@@ -290,7 +360,9 @@ class ConfDict(dict[str, tp.Any]):
         out = _yaml.safe_load(yaml)
         if not isinstance(out, dict):
             raise TypeError(f"Cannot convert non-dict yaml:\n{out}\n(from {input_})")
-        return ConfDict(out)
+        conf = ConfDict()
+        conf._update(out, apply_ops=apply_ops)
+        return conf
 
     def to_yaml(self, filepath: Path | str | None = None) -> str:
         """Exports the ConfDict to yaml string

--- a/exca/confdict.py
+++ b/exca/confdict.py
@@ -291,15 +291,15 @@ class ConfDict(dict[str, tp.Any], metaclass=_ConfDictMeta):
 
         Example
         -------
-        .. code-block:: python
-
-            cfg = ConfDict({"a": {"x": 1}, "b": {"x": 2}})
-
-            cfg.update({"a": {ConfDict.ops.REPLACE: True, "y": 4}, "b": {"y": 12}})
-            >> {"a": {"y": 4}, "b": {"x": 2, "y": 12}}
-
-            cfg.update({"a": {ConfDict.ops.AFTER: "b"}, "b.x": ConfDict.ops.DELETE})
-            >> {"b": {"y": 12}, "a": {"y": 4}}
+        >>> cfg = ConfDict({"a": {"x": 1}, "b": {"x": 2}})
+        >>> cfg.update(
+        ...     {
+        ...         "a": {ConfDict.ops.REPLACE: True, ConfDict.ops.AFTER: "b", "y": 4},
+        ...         "b": {"y": 12},
+        ...     }
+        ... )
+        >>> cfg
+        {'b': {'x': 2, 'y': 12}, 'a': {'y': 4}}
         """
         self._update(mapping, **kwargs)
 

--- a/exca/confdict.py
+++ b/exca/confdict.py
@@ -60,9 +60,6 @@ def _is_seq(val: tp.Any) -> tp.TypeGuard[tp.Sequence[tp.Any]]:
 
 
 def _apply_move(obj: dict[str, tp.Any], key: str) -> None:
-    """Reorder obj to place key =before=/=after= the anchor named by the op in
-    obj[key]. A missing anchor leaves the op in place for a later update.
-    """
     sub = obj[key]
     present = [op for op in (ConfDict.ops.BEFORE, ConfDict.ops.AFTER) if op in sub]
     if len(present) > 1:
@@ -163,7 +160,8 @@ def _set_item(obj: tp.Any, key: str, val: tp.Any) -> None:
             raise TypeError(f"Cannot delete key {p!r} on existing sequence {obj!r}")
         dict.pop(obj, p, None)
         return
-    ConfDict.ops.is_op(val)
+    if ConfDict.ops.is_op(val) and val != ConfDict.ops.DELETE:
+        raise ValueError(f"Unexpected ConfDict op value {val!r}")
     # list case
     if _is_seq(obj):
         obj[p] = val  # type: ignore
@@ -288,6 +286,8 @@ class ConfDict(dict[str, tp.Any], metaclass=_ConfDictMeta):
         Dicts merge by default. :code:`ConfDict.ops.REPLACE` replaces a mapping,
         :code:`ConfDict.ops.DELETE` removes a key, and
         :code:`ConfDict.ops.BEFORE` / :code:`ConfDict.ops.AFTER` move a key.
+        Patches apply top to bottom: each mapping entry merges content, then
+        moves itself if its anchor exists. Otherwise, the op remains.
 
         Example
         -------

--- a/exca/confdict.py
+++ b/exca/confdict.py
@@ -486,7 +486,7 @@ class UidMaker:
         elif isinstance(data, dict):
             for k in data:
                 # _to_simplified_dict may fuse an op into a dotted key (a.=op=)
-                if "=" in k and any(ConfDict.ops.is_op(p) for p in k.split(".")):
+                if any(ConfDict.ops.is_op(p) for p in k.split(".")):
                     raise ValueError(f"Cannot compute uid on unresolved config {k!r}")
             udata = {x: UidMaker(y, version=version) for x, y in data.items()}
             if version > 2:
@@ -525,6 +525,8 @@ class UidMaker:
             else:
                 self.string = f"{data:.2e}"
         elif isinstance(data, (str, int, np.int32, np.int64)) or data is None:
+            if ConfDict.ops.is_op(data):
+                raise ValueError(f"Cannot compute uid on unresolved config {data!r}")
             self.string = str(data)
             self.hash = self.string
             typestr = "str" if isinstance(data, str) else "int"

--- a/exca/confdict.py
+++ b/exca/confdict.py
@@ -59,90 +59,90 @@ def _is_seq(val: tp.Any) -> tp.TypeGuard[tp.Sequence[tp.Any]]:
     return isinstance(val, abc.Sequence) and not isinstance(val, str)
 
 
-def _propagate_confdict(
-    obj: tp.Any, replace_dicts: bool = False, *, apply_ops: bool
-) -> tp.Any:
-    """Recursively cast content of list and ordered dict to to confdicts"""
-    # Note: avoid replacing native dicts as they may contain ConfDict.ops.REPLACE tag
-    # which needs to be processed later on
-    params = dict(replace_dicts=True, apply_ops=apply_ops)
-    if isinstance(obj, OrderedDict):
-        sub = {x: _propagate_confdict(y, **params) for x, y in obj.items()}
-        return OrderedDict(sub)
-    if replace_dicts and isinstance(obj, dict):
-        sub = ConfDict()
-        sub._update(obj, apply_ops=apply_ops)
-        return sub
-    if _is_seq(obj):
-        Container = obj.__class__
-        return Container([_propagate_confdict(v, **params) for v in obj])  # type: ignore
-    if isinstance(obj, dict):
-        return obj
-    if isinstance(obj, ConfDict):
-        return obj
-    return obj
+_Move = tuple[str, str]
 
 
-def _move_key(
-    obj: dict[str, tp.Any], key: str, *, before: str | None, after: str | None
-) -> None:
-    if before is not None and after is not None:
+def _move_from_mapping(val: dict[str, tp.Any]) -> _Move | None:
+    moves = []
+    for op in (ConfDict.ops.BEFORE, ConfDict.ops.AFTER):
+        if op not in val:
+            continue
+        anchor = val[op]
+        if not isinstance(anchor, str):
+            raise TypeError(f"{op!r} expects a key name, got {anchor!r}")
+        moves.append((op, anchor))
+    if len(moves) > 1:
         raise ValueError(
             f"Use either {ConfDict.ops.BEFORE!r} or {ConfDict.ops.AFTER!r}, not both"
         )
-    anchor = before if before is not None else after
-    if anchor is None:
-        return
+    return moves[0] if moves else None
+
+
+def _move_key(obj: dict[str, tp.Any], key: str, move: _Move) -> None:
+    op, anchor = move
     if anchor == key:
         raise ValueError(f"Cannot move {key!r} relative to itself")
-    if anchor not in obj:
-        raise KeyError(f"Cannot move {key!r}: anchor {anchor!r} is missing")
     value = dict.pop(obj, key)
     items = list(obj.items())
     obj.clear()
     for name, item in items:
-        if before is not None and name == anchor:
-            obj[key] = value
-        obj[name] = item
-        if after is not None and name == anchor:
-            obj[key] = value
+        if op == ConfDict.ops.BEFORE and name == anchor:
+            dict.__setitem__(obj, key, value)
+        dict.__setitem__(obj, name, item)
+        if op == ConfDict.ops.AFTER and name == anchor:
+            dict.__setitem__(obj, key, value)
 
 
-def _update_mapping(
-    obj: dict[str, tp.Any], key: str, val: dict[str, tp.Any], *, apply_ops: bool
-) -> None:
-    val = dict(val)
-    before: str | None = None
-    after: str | None = None
-    if apply_ops and ConfDict.ops.BEFORE in val:
-        before = val.pop(ConfDict.ops.BEFORE)
-        if not isinstance(before, str):
-            raise TypeError(f"{ConfDict.ops.BEFORE!r} expects a key name, got {before!r}")
-    if apply_ops and ConfDict.ops.AFTER in val:
-        after = val.pop(ConfDict.ops.AFTER)
-        if not isinstance(after, str):
-            raise TypeError(f"{ConfDict.ops.AFTER!r} expects a key name, got {after!r}")
-    if val:
-        if isinstance(obj[key], ConfDict):
-            sub = obj[key]
-        elif isinstance(obj[key], dict):
-            sub = ConfDict()
-            sub._update(obj[key], apply_ops=apply_ops)
-            dict.__setitem__(obj, key, sub)
-        else:
-            sub = ConfDict()
-            dict.__setitem__(obj, key, sub)
-        sub._update(val, apply_ops=apply_ops)
-    _move_key(obj, key, before=before, after=after)
+def _propagate_confdict(obj: tp.Any, replace_dicts: bool = False) -> tp.Any:
+    """Recursively cast content of list and ordered dict to to confdicts"""
+    # Note: avoid replacing native dicts as they may contain ConfDict.ops.REPLACE tag
+    # which needs to be processed later on
+    if isinstance(obj, ConfDict):
+        return obj
+    if isinstance(obj, OrderedDict):
+        sub = {x: _propagate_confdict(y, replace_dicts=True) for x, y in obj.items()}
+        return OrderedDict(sub)
+    if replace_dicts and isinstance(obj, dict):
+        sub = ConfDict()
+        sub._update(obj)
+        return sub
+    if _is_seq(obj):
+        Container = obj.__class__
+        return Container([_propagate_confdict(v, replace_dicts=True) for v in obj])  # type: ignore
+    if isinstance(obj, dict):
+        return obj
+    return obj
 
 
-def _set_item(obj: tp.Any, key: str, val: tp.Any, *, apply_ops: bool) -> None:
+def _update_mapping(obj: dict[str, tp.Any], key: str, val: dict[str, tp.Any]) -> None:
+    move = _move_from_mapping(val)
+    if isinstance(obj[key], ConfDict):
+        sub = obj[key]
+    elif isinstance(obj[key], dict):
+        sub = ConfDict()
+        sub._update(obj[key])
+        dict.__setitem__(obj, key, sub)
+    else:
+        sub = ConfDict()
+        dict.__setitem__(obj, key, sub)
+    sub._update(val)
+    if move is not None and move[1] in obj:
+        _move_key(obj, key, move)
+        value = obj[key]
+        if isinstance(value, dict):
+            op, _ = move
+            dict.pop(value, op, None)
+
+
+def _set_item(obj: tp.Any, key: str, val: tp.Any) -> None:
     """Internal recursive setitem on ConfDict/list"""
     p, *rest = key.split(".", maxsplit=1)
     if isinstance(obj, dict):
+        existed = p in obj
         sub = obj.setdefault(p, ConfDict())
     elif _is_seq(obj) and p.isdigit():
         p = int(p)  # type: ignore
+        existed = True
         sub = obj[p]  # type: ignore
     else:
         raise TypeError(f"Cannot handle key {p!r} on existing container {obj!r}")
@@ -154,9 +154,9 @@ def _set_item(obj: tp.Any, key: str, val: tp.Any, *, apply_ops: bool) -> None:
                 obj[p] = sub  # type: ignore
             else:
                 dict.__setitem__(obj, p, sub)
-        _set_item(sub, rest[0], val, apply_ops=apply_ops)
+        _set_item(sub, rest[0], val)
         if (
-            apply_ops
+            existed
             and val == ConfDict.ops.DELETE
             and isinstance(obj, dict)
             and isinstance(sub, dict)
@@ -165,22 +165,20 @@ def _set_item(obj: tp.Any, key: str, val: tp.Any, *, apply_ops: bool) -> None:
             dict.pop(obj, p, None)
         return
     # final part
-    val = _propagate_confdict(val, replace_dicts=False, apply_ops=apply_ops)
-    if apply_ops and val == ConfDict.ops.DELETE:
+    val = _propagate_confdict(val, replace_dicts=False)
+    if val == ConfDict.ops.DELETE and existed:
         if _is_seq(obj):
             raise TypeError(f"Cannot delete key {p!r} on existing sequence {obj!r}")
         dict.pop(obj, p, None)
         return
-    if apply_ops and ConfDict.ops.is_op(val):
-        raise ValueError(f"Unexpected ConfDict op value {val!r}")
+    ConfDict.ops.is_op(val)
     # list case
     if _is_seq(obj):
         obj[p] = val  # type: ignore
         return
-    if apply_ops and ConfDict.ops.is_op(p):
-        raise ValueError(f"Unexpected ConfDict op key {p!r}")
+    ConfDict.ops.is_op(p)
     if isinstance(val, dict) and not isinstance(val, OrderedDict):
-        _update_mapping(obj, p, val, apply_ops=apply_ops)
+        _update_mapping(obj, p, val)
     else:
         dict.__setitem__(obj, p, val)
 
@@ -212,7 +210,7 @@ class ConfDict(dict[str, tp.Any], metaclass=_ConfDictMeta):
 
     def __init__(self, mapping: Mapping | None = None, **kwargs: tp.Any) -> None:
         super().__init__()
-        self._update(mapping, apply_ops=True, **kwargs)
+        self._update(mapping, **kwargs)
 
     @classmethod
     def from_model(
@@ -243,7 +241,7 @@ class ConfDict(dict[str, tp.Any], metaclass=_ConfDictMeta):
     def __setitem__(self, key: str, val: tp.Any) -> None:
         if not isinstance(key, str):
             raise TypeError(f"ConfDict only supports str keys, got {key!r}")
-        _set_item(self, key, val, apply_ops=True)
+        _set_item(self, key, val)
 
     def __getitem__(self, key: str) -> tp.Any:
         parts = key.split(".")
@@ -311,23 +309,22 @@ class ConfDict(dict[str, tp.Any], metaclass=_ConfDictMeta):
             cfg.update({"a": {ConfDict.ops.AFTER: "b"}, "b.x": ConfDict.ops.DELETE})
             >> {"b": {"y": 12}, "a": {"y": 4}}
         """
-        self._update(mapping, apply_ops=True, **kwargs)
+        self._update(mapping, **kwargs)
 
-    def _update(
-        self, mapping: Mapping | None = None, *, apply_ops: bool, **kwargs: tp.Any
-    ) -> None:
+    def _update(self, mapping: Mapping | None = None, **kwargs: tp.Any) -> None:
         if mapping is not None:
             if not isinstance(mapping, abc.Mapping):
                 mapping = dict(mapping)
             kwargs.update(mapping)
         if not kwargs:
             return
-        if apply_ops and kwargs.pop(ConfDict.ops.REPLACE, False):
+        if kwargs.get(ConfDict.ops.REPLACE, False) and self:
+            kwargs.pop(ConfDict.ops.REPLACE)
             self.clear()
         for key, val in kwargs.items():
             if not isinstance(key, str):
                 raise TypeError(f"ConfDict only supports str keys, got {key!r}")
-            _set_item(self, key, val, apply_ops=apply_ops)
+            _set_item(self, key, val)
 
     def flat(self) -> dict[str, tp.Any]:
         """Returns a flat dictionary such as
@@ -342,8 +339,6 @@ class ConfDict(dict[str, tp.Any], metaclass=_ConfDictMeta):
     def from_yaml(
         cls,
         yaml: str | Path | tp.IO[str] | tp.IO[bytes],
-        *,
-        apply_ops: bool = True,
     ) -> "ConfDict":
         """Loads a ConfDict from a yaml string/filepath/file handle."""
         input_ = yaml
@@ -361,7 +356,7 @@ class ConfDict(dict[str, tp.Any], metaclass=_ConfDictMeta):
         if not isinstance(out, dict):
             raise TypeError(f"Cannot convert non-dict yaml:\n{out}\n(from {input_})")
         conf = ConfDict()
-        conf._update(out, apply_ops=apply_ops)
+        conf._update(out)
         return conf
 
     def to_yaml(self, filepath: Path | str | None = None) -> str:

--- a/exca/confdict.py
+++ b/exca/confdict.py
@@ -59,29 +59,27 @@ def _is_seq(val: tp.Any) -> tp.TypeGuard[tp.Sequence[tp.Any]]:
     return isinstance(val, abc.Sequence) and not isinstance(val, str)
 
 
-_Move = tuple[str, str]
-
-
-def _move_from_mapping(val: dict[str, tp.Any]) -> _Move | None:
-    moves = []
-    for op in (ConfDict.ops.BEFORE, ConfDict.ops.AFTER):
-        if op not in val:
-            continue
-        anchor = val[op]
-        if not isinstance(anchor, str):
-            raise TypeError(f"{op!r} expects a key name, got {anchor!r}")
-        moves.append((op, anchor))
-    if len(moves) > 1:
+def _apply_move(obj: dict[str, tp.Any], key: str) -> None:
+    """Reorder obj to place key =before=/=after= the anchor named by the op in
+    obj[key]. A missing anchor leaves the op in place for a later update.
+    """
+    sub = obj[key]
+    present = [op for op in (ConfDict.ops.BEFORE, ConfDict.ops.AFTER) if op in sub]
+    if len(present) > 1:
         raise ValueError(
             f"Use either {ConfDict.ops.BEFORE!r} or {ConfDict.ops.AFTER!r}, not both"
         )
-    return moves[0] if moves else None
-
-
-def _move_key(obj: dict[str, tp.Any], key: str, move: _Move) -> None:
-    op, anchor = move
+    if not present:
+        return
+    op = present[0]
+    anchor = sub[op]
+    if not isinstance(anchor, str):
+        raise TypeError(f"{op!r} expects a key name, got {anchor!r}")
     if anchor == key:
         raise ValueError(f"Cannot move {key!r} relative to itself")
+    if anchor not in obj:
+        return
+    dict.pop(sub, op, None)
     value = dict.pop(obj, key)
     items = list(obj.items())
     obj.clear()
@@ -115,7 +113,6 @@ def _propagate_confdict(obj: tp.Any, replace_dicts: bool = False) -> tp.Any:
 
 
 def _update_mapping(obj: dict[str, tp.Any], key: str, val: dict[str, tp.Any]) -> None:
-    move = _move_from_mapping(val)
     if isinstance(obj[key], ConfDict):
         sub = obj[key]
     elif isinstance(obj[key], dict):
@@ -126,12 +123,7 @@ def _update_mapping(obj: dict[str, tp.Any], key: str, val: dict[str, tp.Any]) ->
         sub = ConfDict()
         dict.__setitem__(obj, key, sub)
     sub._update(val)
-    if move is not None and move[1] in obj:
-        _move_key(obj, key, move)
-        value = obj[key]
-        if isinstance(value, dict):
-            op, _ = move
-            dict.pop(value, op, None)
+    _apply_move(obj, key)
 
 
 def _set_item(obj: tp.Any, key: str, val: tp.Any) -> None:
@@ -492,6 +484,10 @@ class UidMaker:
                 self.hash = h
             typestr = "array"
         elif isinstance(data, dict):
+            for k in data:
+                # _to_simplified_dict may fuse an op into a dotted key (a.=op=)
+                if "=" in k and any(ConfDict.ops.is_op(p) for p in k.split(".")):
+                    raise ValueError(f"Cannot compute uid on unresolved config {k!r}")
             udata = {x: UidMaker(y, version=version) for x, y in data.items()}
             if version > 2:
                 if isinstance(data, OrderedDict):

--- a/exca/confdict.py
+++ b/exca/confdict.py
@@ -153,7 +153,7 @@ def _set_item(obj: tp.Any, key: str, val: tp.Any) -> None:
     if isinstance(val, dict) and not isinstance(val, OrderedDict):
         if isinstance(sub, OrderedDict):
             patched = ConfDict(sub)
-            patched.update(val)
+            patched.update(val)  # degrades to dict
             sub.clear()
             sub.update(OrderedDict(patched.items()))
         elif not isinstance(sub, ConfDict):
@@ -183,7 +183,7 @@ class ConfDict(dict[str, tp.Any], metaclass=_ConfDictMeta):
     ----
     - This is designed for configurations, so it probably does not scale well to 100k+ keys
     - Updates apply patches: mappings that merge dict values recursively and
-      may contain operation tokens. See :code:`ConfDict.update`..
+      may contain operation tokens. See :code:`ConfDict.update`.
     """
 
     LATEST_UID_VERSION = 3

--- a/exca/confdict.py
+++ b/exca/confdict.py
@@ -113,6 +113,12 @@ def _propagate_confdict(obj: tp.Any, replace_dicts: bool = False) -> tp.Any:
 def _set_item(obj: tp.Any, key: str, val: tp.Any) -> None:
     """Internal recursive setitem on ConfDict/list"""
     p, *rest = key.split(".", maxsplit=1)
+    if not rest:
+        val = _propagate_confdict(val, replace_dicts=False)
+        if ConfDict.ops.is_op(val) and val != ConfDict.ops.DELETE:
+            raise ValueError(f"Unexpected ConfDict op value {val!r}")
+        if isinstance(obj, dict):
+            ConfDict.ops.is_op(p)  # reject op-shaped typos used as keys
     if isinstance(obj, dict):
         existed = p in obj
         sub = obj.setdefault(p, ConfDict())
@@ -133,21 +139,16 @@ def _set_item(obj: tp.Any, key: str, val: tp.Any) -> None:
         _set_item(sub, rest[0], val)
         return
     # final part
-    val = _propagate_confdict(val, replace_dicts=False)
     if val == ConfDict.ops.DELETE and existed:
         if _is_seq(obj):
             raise TypeError(f"Cannot delete key {p!r} on existing sequence {obj!r}")
         dict.pop(obj, p, None)
         return
-    if ConfDict.ops.is_op(val) and val != ConfDict.ops.DELETE:
-        raise ValueError(f"Unexpected ConfDict op value {val!r}")
     # list case
     if _is_seq(obj):
         obj[p] = val  # type: ignore
         return
-    ConfDict.ops.is_op(p)  # reject op-shaped typos used as keys
     if isinstance(val, dict) and not isinstance(val, OrderedDict):
-        sub = obj[p]
         if isinstance(sub, OrderedDict):
             patched = ConfDict(sub)
             patched.update(val)

--- a/exca/confdict.py
+++ b/exca/confdict.py
@@ -165,7 +165,8 @@ def _set_item(obj: tp.Any, key: str, val: tp.Any) -> None:
 
 
 class ConfDict(dict[str, tp.Any], metaclass=_ConfDictMeta):
-    """Dictionary which breaks into sub-dictionnaries on "." as in a config (see example)
+    """Dictionary which breaks into sub-dictionnaries on "." as in a config (see example),
+    and merges recursively.
     The data can be specified either through "." keywords or directly through sub-dicts
     or a mixture of both.
     Lists of dictionaries are processed as list of ConfDict
@@ -178,13 +179,8 @@ class ConfDict(dict[str, tp.Any], metaclass=_ConfDictMeta):
     Note
     ----
     - This is designed for configurations, so it probably does not scale well to 100k+ keys
-    - dicts are merged except if containing the key :code:`ConfDict.ops.REPLACE`,
-      in which case they replace the content. The scalar value
-      :code:`ConfDict.ops.DELETE` deletes a key. The keys
-      :code:`ConfDict.ops.BEFORE` and :code:`ConfDict.ops.AFTER` move a key
-      within the containing mapping (see :code:`ConfDict.update`) for an example).
-    - Patches apply top to bottom: each mapping entry merges content, then
-      moves itself if its anchor exists. Otherwise, the op remains.
+    - Updates apply patches: mappings that merge dict values recursively and
+      may contain operation tokens. See :code:`ConfDict.update`.
     """
 
     LATEST_UID_VERSION = 3
@@ -270,6 +266,21 @@ class ConfDict(dict[str, tp.Any], metaclass=_ConfDictMeta):
         self, mapping: Mapping | None = None, **kwargs: tp.Any
     ) -> None:
         """Apply a patch using the ConfDict merge rules.
+
+        Rules
+        -----
+        - dict values merge recursively.
+        - non-dict values replace existing values.
+        - operations (see below) apply top to bottom; unresolved ops stay in the config until
+          applicable.
+
+        Operations
+        -----------
+        - :code:`ConfDict.ops.DELETE` as value to a key deletes the key altogether.
+        - :code:`ConfDict.ops.REPLACE` as key with True value replaces the whole
+          existing content with the new one instead of merging recursively.
+        - :code:`ConfDict.ops.BEFORE` and :code:`ConfDict.ops.AFTER` reorders a key
+          relative to an existing sibling.
 
         Example
         -------

--- a/exca/confdict.py
+++ b/exca/confdict.py
@@ -25,7 +25,6 @@ from . import utils
 logger = logging.getLogger(__name__)
 Mapping = tp.MutableMapping[str, tp.Any] | tp.Iterable[tuple[str, tp.Any]]
 _sentinel = object()
-OVERRIDE = "=replace="
 
 
 def _is_seq(val: tp.Any) -> tp.TypeGuard[tp.Sequence[tp.Any]]:
@@ -34,7 +33,7 @@ def _is_seq(val: tp.Any) -> tp.TypeGuard[tp.Sequence[tp.Any]]:
 
 def _propagate_confdict(obj: tp.Any, replace_dicts: bool = False) -> tp.Any:
     """Recursively cast content of list and ordered dict to to confdicts"""
-    # Note: avoid replacing native dicts as they may contain OVERRIDE tag
+    # Note: avoid replacing native dicts as they may contain ConfDict.OVERRIDE tag
     # which needs to be processed later on
     if isinstance(obj, OrderedDict):
         sub = {x: _propagate_confdict(y, replace_dicts=True) for x, y in obj.items()}
@@ -51,6 +50,51 @@ def _propagate_confdict(obj: tp.Any, replace_dicts: bool = False) -> tp.Any:
     return obj
 
 
+def _move_key(
+    obj: dict[str, tp.Any], key: str, *, before: str | None, after: str | None
+) -> None:
+    if before is not None and after is not None:
+        raise ValueError(
+            f"Use either {ConfDict.BEFORE!r} or {ConfDict.AFTER!r}, not both"
+        )
+    anchor = before if before is not None else after
+    if anchor is None:
+        return
+    if anchor == key:
+        raise ValueError(f"Cannot move {key!r} relative to itself")
+    if anchor not in obj:
+        raise KeyError(f"Cannot move {key!r}: anchor {anchor!r} is missing")
+    value = dict.pop(obj, key)
+    items = list(obj.items())
+    obj.clear()
+    for name, item in items:
+        if before is not None and name == anchor:
+            obj[key] = value
+        obj[name] = item
+        if after is not None and name == anchor:
+            obj[key] = value
+
+
+def _update_mapping(obj: dict[str, tp.Any], key: str, val: dict[str, tp.Any]) -> None:
+    val = dict(val)
+    before: str | None = None
+    after: str | None = None
+    if ConfDict.BEFORE in val:
+        before = val.pop(ConfDict.BEFORE)
+        if not isinstance(before, str):
+            raise TypeError(f"{ConfDict.BEFORE!r} expects a key name, got {before!r}")
+    if ConfDict.AFTER in val:
+        after = val.pop(ConfDict.AFTER)
+        if not isinstance(after, str):
+            raise TypeError(f"{ConfDict.AFTER!r} expects a key name, got {after!r}")
+    if val:
+        if isinstance(obj[key], dict):
+            obj[key].update(val)
+        else:
+            dict.__setitem__(obj, key, ConfDict(val))
+    _move_key(obj, key, before=before, after=after)
+
+
 def _set_item(obj: tp.Any, key: str, val: tp.Any) -> None:
     """Internal recursive setitem on ConfDict/list"""
     p, *rest = key.split(".", maxsplit=1)
@@ -61,24 +105,36 @@ def _set_item(obj: tp.Any, key: str, val: tp.Any) -> None:
         sub = obj[p]  # type: ignore
     else:
         raise TypeError(f"Cannot handle key {p!r} on existing container {obj!r}")
-    # replace sub by dict if not dict or sequence
-    if not _is_seq(sub) and not isinstance(sub, dict):
-        sub = ConfDict()
-        if _is_seq(obj):
-            obj[p] = sub  # type: ignore
-        else:
-            dict.__setitem__(obj, p, sub)
     if rest:
+        # replace sub by dict if not dict or sequence
+        if not _is_seq(sub) and not isinstance(sub, dict):
+            sub = ConfDict()
+            if _is_seq(obj):
+                obj[p] = sub  # type: ignore
+            else:
+                dict.__setitem__(obj, p, sub)
         _set_item(sub, rest[0], val)
+        if (
+            val == ConfDict.DELETE
+            and isinstance(obj, dict)
+            and isinstance(sub, dict)
+            and not sub
+        ):
+            dict.pop(obj, p, None)
         return
     # final part
     val = _propagate_confdict(val, replace_dicts=False)
+    if val == ConfDict.DELETE:
+        if _is_seq(obj):
+            raise TypeError(f"Cannot delete key {p!r} on existing sequence {obj!r}")
+        dict.pop(obj, p, None)
+        return
     # list case
     if _is_seq(obj):
         obj[p] = val  # type: ignore
         return
     if isinstance(val, dict) and not isinstance(val, OrderedDict):
-        obj[p].update(val)
+        _update_mapping(obj, p, val)
     else:
         dict.__setitem__(obj, p, val)
 
@@ -97,14 +153,18 @@ class ConfDict(dict[str, tp.Any]):
     Note
     ----
     - This is designed for configurations, so it probably does not scale well to 100k+ keys
-    - dicts are merged expect if containing the key :code:`"=replace="`,
-      in which case they replace the content. On the other hand, non-dicts always
-      replace the content.
+    - dicts are merged except if containing the key :code:`ConfDict.OVERRIDE`,
+      in which case they replace the content. The scalar value
+      :code:`ConfDict.DELETE` deletes a key. The keys :code:`ConfDict.BEFORE`
+      and :code:`ConfDict.AFTER` move a key within the containing mapping.
     """
 
     LATEST_UID_VERSION = 3
     UID_VERSION = int(os.environ.get("CONFDICT_UID_VERSION", LATEST_UID_VERSION))
-    OVERRIDE = OVERRIDE  # convenient to have it here
+    OVERRIDE = "=replace="
+    DELETE = "=delete="
+    BEFORE = "=before="
+    AFTER = "=after="
 
     def __init__(self, mapping: Mapping | None = None, **kwargs: tp.Any) -> None:
         super().__init__()
@@ -199,7 +259,7 @@ class ConfDict(dict[str, tp.Any]):
             kwargs.update(mapping)
         if not kwargs:
             return
-        if kwargs.pop(OVERRIDE, False):
+        if kwargs.pop(ConfDict.OVERRIDE, False):
             self.clear()
         for key, val in kwargs.items():
             self[key] = val
@@ -236,7 +296,7 @@ class ConfDict(dict[str, tp.Any]):
         """Exports the ConfDict to yaml string
         and optionally to a file if a filepath is provided
         """
-        out: str = _yaml.safe_dump(_to_simplified_dict(self), sort_keys=True)
+        out: str = _yaml.safe_dump(_to_simplified_dict(self), sort_keys=False)
         if filepath is not None:
             Path(filepath).write_text(out, encoding="utf8")
         return out

--- a/exca/confdict.py
+++ b/exca/confdict.py
@@ -37,6 +37,9 @@ class ConfDictOps:
 
     @classmethod
     def is_op(cls, value: tp.Any) -> tp.TypeGuard[str]:
+        """True for a known op, False for a non-op token, and raises on an
+        op-shaped string (:code:`=...=`) that is not a known op (typo guard).
+        """
         if not isinstance(value, str) or cls._PATTERN.fullmatch(value) is None:
             return False
         if value not in {cls.REPLACE, cls.DELETE, cls.BEFORE, cls.AFTER}:
@@ -98,29 +101,13 @@ def _propagate_confdict(obj: tp.Any, replace_dicts: bool = False) -> tp.Any:
         sub = {x: _propagate_confdict(y, replace_dicts=True) for x, y in obj.items()}
         return OrderedDict(sub)
     if replace_dicts and isinstance(obj, dict):
-        sub = ConfDict()
-        sub._update(obj)
-        return sub
+        return ConfDict(obj)
     if _is_seq(obj):
         Container = obj.__class__
         return Container([_propagate_confdict(v, replace_dicts=True) for v in obj])  # type: ignore
     if isinstance(obj, dict):
         return obj
     return obj
-
-
-def _update_mapping(obj: dict[str, tp.Any], key: str, val: dict[str, tp.Any]) -> None:
-    if isinstance(obj[key], ConfDict):
-        sub = obj[key]
-    elif isinstance(obj[key], dict):
-        sub = ConfDict()
-        sub._update(obj[key])
-        dict.__setitem__(obj, key, sub)
-    else:
-        sub = ConfDict()
-        dict.__setitem__(obj, key, sub)
-    sub._update(val)
-    _apply_move(obj, key)
 
 
 def _set_item(obj: tp.Any, key: str, val: tp.Any) -> None:
@@ -166,9 +153,14 @@ def _set_item(obj: tp.Any, key: str, val: tp.Any) -> None:
     if _is_seq(obj):
         obj[p] = val  # type: ignore
         return
-    ConfDict.ops.is_op(p)
+    ConfDict.ops.is_op(p)  # reject op-shaped typos used as keys
     if isinstance(val, dict) and not isinstance(val, OrderedDict):
-        _update_mapping(obj, p, val)
+        sub = obj[p]
+        if not isinstance(sub, ConfDict):
+            sub = ConfDict(sub) if isinstance(sub, dict) else ConfDict()
+            dict.__setitem__(obj, p, sub)
+        sub.update(val)
+        _apply_move(obj, p)
     else:
         dict.__setitem__(obj, p, val)
 
@@ -202,7 +194,7 @@ class ConfDict(dict[str, tp.Any], metaclass=_ConfDictMeta):
 
     def __init__(self, mapping: Mapping | None = None, **kwargs: tp.Any) -> None:
         super().__init__()
-        self._update(mapping, **kwargs)
+        self.update(mapping, **kwargs)
 
     @classmethod
     def from_model(
@@ -297,17 +289,13 @@ class ConfDict(dict[str, tp.Any], metaclass=_ConfDictMeta):
         >>> cfg
         {'b': {'x': 2, 'y': 12}, 'a': {'y': 4}}
         """
-        self._update(mapping, **kwargs)
-
-    def _update(self, mapping: Mapping | None = None, **kwargs: tp.Any) -> None:
         if mapping is not None:
             if not isinstance(mapping, abc.Mapping):
                 mapping = dict(mapping)
             kwargs.update(mapping)
         if not kwargs:
             return
-        if kwargs.get(ConfDict.ops.REPLACE, False) and self:
-            kwargs.pop(ConfDict.ops.REPLACE)
+        if self and kwargs.pop(ConfDict.ops.REPLACE, False):
             self.clear()
         for key, val in kwargs.items():
             if not isinstance(key, str):
@@ -344,7 +332,7 @@ class ConfDict(dict[str, tp.Any], metaclass=_ConfDictMeta):
         if not isinstance(out, dict):
             raise TypeError(f"Cannot convert non-dict yaml:\n{out}\n(from {input_})")
         conf = ConfDict()
-        conf._update(out)
+        conf.update(out)
         return conf
 
     def to_yaml(self, filepath: Path | str | None = None) -> str:

--- a/exca/confdict.py
+++ b/exca/confdict.py
@@ -191,7 +191,9 @@ class ConfDict(dict[str, tp.Any], metaclass=_ConfDictMeta):
       in which case they replace the content. The scalar value
       :code:`ConfDict.ops.DELETE` deletes a key. The keys
       :code:`ConfDict.ops.BEFORE` and :code:`ConfDict.ops.AFTER` move a key
-      within the containing mapping.
+      within the containing mapping (see :code:`ConfDict.update`) for an example).
+    - Patches apply top to bottom: each mapping entry merges content, then
+      moves itself if its anchor exists. Otherwise, the op remains.
     """
 
     LATEST_UID_VERSION = 3
@@ -281,13 +283,7 @@ class ConfDict(dict[str, tp.Any], metaclass=_ConfDictMeta):
     def update(  # type: ignore
         self, mapping: Mapping | None = None, **kwargs: tp.Any
     ) -> None:
-        """Recursively update the config.
-
-        Dicts merge by default. :code:`ConfDict.ops.REPLACE` replaces a mapping,
-        :code:`ConfDict.ops.DELETE` removes a key, and
-        :code:`ConfDict.ops.BEFORE` / :code:`ConfDict.ops.AFTER` move a key.
-        Patches apply top to bottom: each mapping entry merges content, then
-        moves itself if its anchor exists. Otherwise, the op remains.
+        """Apply a patch using the ConfDict merge rules.
 
         Example
         -------

--- a/exca/helpers.py
+++ b/exca/helpers.py
@@ -482,7 +482,8 @@ class DiscriminatedModel(pydantic.BaseModel):
         cls = type(self)
         key = cls._exca_discriminator_key
         name = cls.__name__
-        result.setdefault(key, name)
+        if key not in result:
+            return {key: name, **result}  # type first for readability
         # serialization can be reentrant in some pydantic version (not sure why)
         # so the field may be prepopulated
         if result[key] != name:

--- a/exca/steps/test_backends.py
+++ b/exca/steps/test_backends.py
@@ -210,13 +210,13 @@ def test_config_files_and_consistency(tmp_path: Path) -> None:
 
     handle = step.lookup(10.0)
     step_folder = handle.paths.step_folder
-    expected_uid = "- coeff: 3.0\n  type: Mult\n"
+    expected_uid = "- type: Mult\n  coeff: 3.0\n"
     assert (step_folder / "uid.yaml").read_text("utf8") == expected_uid
     assert (step_folder / "full-uid.yaml").read_text("utf8") == expected_uid
     assert (step_folder / "config.yaml").exists()
 
     # Inconsistent uid.yaml raises error
-    (step_folder / "uid.yaml").write_text("- coeff: 999.0\n  type: Mult\n")
+    (step_folder / "uid.yaml").write_text("- type: Mult\n  coeff: 999.0\n")
     step.lookup(10.0).clear_cache()
     with pytest.raises(RuntimeError, match="Inconsistent uid config"):
         step.run(10.0)

--- a/exca/steps/test_steps.py
+++ b/exca/steps/test_steps.py
@@ -134,8 +134,8 @@ def test_chain_hash_and_uid(with_infra: bool, tmp_path: Path) -> None:
     expected_yaml = """steps:
 - type: Add
   value: 12.0
-- coeff: 3.0
-  type: Mult
+- type: Mult
+  coeff: 3.0
 - type: Add
   value: 12.0
 """

--- a/exca/test_confdict.py
+++ b/exca/test_confdict.py
@@ -217,6 +217,26 @@ def test_update_delete_happens_before_later_move() -> None:
     assert data["steps.a.=after="] == "b"
 
 
+def test_update_resolves_dangling_move_when_key_is_updated_again() -> None:
+    data = ConfDict({"steps": {"read": {}, "resample": {ConfDict.ops.AFTER: "project"}}})
+    assert list(data["steps"]) == ["read", "resample"], "anchor absent -> dangling"
+
+    # adding the anchor alone does not resolve it: resample must be merged again
+    data.update({"steps": {"project": {}}})
+    assert list(data["steps"]) == ["read", "resample", "project"]
+
+    data.update({"steps": {"resample": {"t": 1}}})
+    assert list(data["steps"]) == ["read", "project", "resample"]
+    assert data["steps.resample"] == {"t": 1}, "op consumed once applied"
+
+
+def test_to_uid_rejects_unresolved_move() -> None:
+    data = ConfDict({"steps": {"read": {}, "resample": {ConfDict.ops.AFTER: "project"}}})
+    assert data.to_yaml()  # dangling ops stay renderable
+    with pytest.raises(ValueError, match="unresolved config"):
+        data.to_uid()
+
+
 @pytest.mark.parametrize(
     "update",
     [
@@ -228,6 +248,14 @@ def test_update_move_errors(update: dict[str, tp.Any]) -> None:
     data = ConfDict({"steps": {"a": {}, "b": {}}})
     with pytest.raises(ValueError):
         data.update(update)
+
+
+def test_update_combines_replace_and_move() -> None:
+    data = ConfDict({"steps": {"a": {"x": 1}, "b": {}}})
+    update = {ConfDict.ops.REPLACE: True, ConfDict.ops.AFTER: "b", "z": 9}
+    data.update({"steps": {"a": update}})
+    assert list(data["steps"]) == ["b", "a"]
+    assert data["steps.a"] == {"z": 9}, "content replaced, then key moved"
 
 
 def test_update_rejects_unknown_ops() -> None:

--- a/exca/test_confdict.py
+++ b/exca/test_confdict.py
@@ -109,46 +109,46 @@ def test_update_delete_and_move() -> None:
         """
     data = ConfDict.from_yaml(base)
     patch = ConfDict.from_yaml(
-        """
+        f"""
         steps:
-          clean: =delete=
+          clean: {ConfDict.ops.DELETE}
           project:
-            =after=: read
+            {ConfDict.ops.AFTER}: read
             t: project
           resample:
-            =after=: project
+            {ConfDict.ops.AFTER}: project
             frequency: 2
           pad:
-            =before=: resample
+            {ConfDict.ops.BEFORE}: resample
           late:
-            =after=: missing
+            {ConfDict.ops.AFTER}: missing
         """
     )
     assert (
         patch.to_yaml()
-        == """steps:
-  clean: =delete=
+        == f"""steps:
+  clean: {ConfDict.ops.DELETE}
   project:
-    =after=: read
+    {ConfDict.ops.AFTER}: read
     t: project
-  pad: {}
+  pad: {{}}
   resample.frequency: 2
-  late.=after=: missing
+  late.{ConfDict.ops.AFTER}: missing
 """
-    )
+    ), "patch should have resolved eagerly what could be"
 
     data.update(patch)
 
     assert (
         data.to_yaml()
-        == """steps:
+        == f"""steps:
   read.t: read
   project.t: project
   resample:
     t: resample
     frequency: 2
   pad.t: pad
-  late.=after=: missing
+  late.{ConfDict.ops.AFTER}: missing
 item:
   name: old
   size: 1
@@ -171,7 +171,6 @@ item:
     grid = ConfDict({"item": [{ConfDict.ops.REPLACE: True, "name": "new"}]})
     data.update({"item": grid.flat()["item"][0]})
     assert data["item"] == {"name": "new"}
-
     data.update({"item.name": ConfDict.ops.DELETE})
     assert data["item"] == {}
 

--- a/exca/test_confdict.py
+++ b/exca/test_confdict.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 import torch
+import yaml
 
 from . import confdict
 from .confdict import ConfDict
@@ -72,6 +73,60 @@ def test_update() -> None:
     assert data == {"a": {"b": {"d": 12}, "c": 1}}
     data["a.b"] = {"e": 15, ConfDict.OVERRIDE: True}
     assert data == {"a": {"b": {"e": 15}, "c": 1}}
+
+
+def test_update_delete_and_move() -> None:
+    data = ConfDict.from_yaml(
+        """
+        steps:
+          read.t: read
+          clean.t: clean
+          resample.t: resample
+          pad.t: pad
+        """
+    )
+    data.update(
+        yaml.safe_load(
+            """
+            steps:
+              clean: =delete=
+              project:
+                =after=: read
+                t: project
+              resample:
+                =after=: project
+                frequency: 2
+              pad:
+                =before=: resample
+            """
+        )
+    )
+
+    assert (
+        data.to_yaml()
+        == """steps:
+  read.t: read
+  project.t: project
+  pad.t: pad
+  resample:
+    t: resample
+    frequency: 2
+"""
+    )
+
+
+@pytest.mark.parametrize(
+    "update",
+    [
+        {"steps": {"a": {ConfDict.BEFORE: "b", ConfDict.AFTER: "b"}}},
+        {"steps": {"a": {ConfDict.AFTER: "a"}}},
+        {"steps": {"a": {ConfDict.AFTER: "missing"}}},
+    ],
+)
+def test_update_move_errors(update: dict[str, tp.Any]) -> None:
+    data = ConfDict({"steps": {"a": {}, "b": {}}})
+    with pytest.raises((KeyError, ValueError)):
+        data.update(update)
 
 
 @pytest.mark.parametrize(
@@ -289,6 +344,20 @@ def test_dict_hash() -> None:
     maker2 = confdict.UidMaker({"x": 1.2, "z": ("z", 12.0)}, version=3)
     assert maker1.hash != maker2.hash
     assert maker1.hash == "dict:{x=float:461168601842738689,y=seq:(str:z,int:12)}"
+
+
+def test_uid_ordering_rules() -> None:
+    cfg = ConfDict.from_yaml("a: 1\nb: 2\n")
+    reversed_cfg = ConfDict.from_yaml("b: 2\na: 1\n")
+    ordered = OrderedDict([("a", 1), ("b", 2)])
+    reversed_ordered = OrderedDict([("b", 2), ("a", 1)])
+
+    assert cfg.to_yaml() != reversed_cfg.to_yaml()
+    assert cfg.to_uid() == reversed_cfg.to_uid()
+    assert (
+        confdict.UidMaker(ordered).format()
+        != confdict.UidMaker(reversed_ordered).format()
+    )
 
 
 def test_set_hash() -> None:

--- a/exca/test_confdict.py
+++ b/exca/test_confdict.py
@@ -14,7 +14,6 @@ from pathlib import Path
 import numpy as np
 import pytest
 import torch
-import yaml
 
 from . import confdict
 from .confdict import ConfDict
@@ -53,26 +52,41 @@ def test_simplified_dict_2() -> None:
 
 def test_update_override() -> None:
     data = ConfDict({"a": 12, "b": 12})
-    data.update({ConfDict.OVERRIDE: True, "d": 13})
+    data.update({ConfDict.ops.REPLACE: True, "d": 13})
     assert data == {"d": 13}
+
+
+def test_override_deprecation() -> None:
+    with pytest.warns(DeprecationWarning, match="ConfDict.ops.REPLACE"):
+        assert ConfDict.OVERRIDE == ConfDict.ops.REPLACE
 
 
 def test_update() -> None:
     data = ConfDict({"a": {"c": 12}, "b": {"c": 12}})
-    data.update(a={ConfDict.OVERRIDE: True, "d": 13}, b={"d": 13})
+    data.update(a={ConfDict.ops.REPLACE: True, "d": 13}, b={"d": 13})
     assert data == {"a": {"d": 13}, "b": {"c": 12, "d": 13}}
     # more complex
     data = ConfDict({"a": {"b": {"c": 12}}})
-    data.update(a={"b": {"d": 12, ConfDict.OVERRIDE: True}})
+    data.update(a={"b": {"d": 12, ConfDict.ops.REPLACE: True}})
     assert data == {"a": {"b": {"d": 12}}}
     # with compressed key
-    data.update(**{"a.b": {"e": 13, ConfDict.OVERRIDE: True}})
+    data.update(**{"a.b": {"e": 13, ConfDict.ops.REPLACE: True}})
     assert data == {"a": {"b": {"e": 13}}}
     # assignment
-    data["a"] = {"c": 1, "b": {"d": 12, ConfDict.OVERRIDE: True}}
+    data["a"] = {"c": 1, "b": {"d": 12, ConfDict.ops.REPLACE: True}}
     assert data == {"a": {"b": {"d": 12}, "c": 1}}
-    data["a.b"] = {"e": 15, ConfDict.OVERRIDE: True}
+    data["a.b"] = {"e": 15, ConfDict.ops.REPLACE: True}
     assert data == {"a": {"b": {"e": 15}, "c": 1}}
+
+
+def test_update_ops_example() -> None:
+    data = ConfDict({"a": {"x": 1}, "b": {"x": 2}})
+
+    data.update({"a": {ConfDict.ops.REPLACE: True, "y": 4}, "b": {"y": 12}})
+    assert data == {"a": {"y": 4}, "b": {"x": 2, "y": 12}}
+
+    data.update({"a": {ConfDict.ops.AFTER: "b"}, "b.x": ConfDict.ops.DELETE})
+    assert data == {"b": {"y": 12}, "a": {"y": 4}}
 
 
 def test_update_delete_and_move() -> None:
@@ -86,7 +100,7 @@ def test_update_delete_and_move() -> None:
         """
     )
     data.update(
-        yaml.safe_load(
+        ConfDict.from_yaml(
             """
             steps:
               clean: =delete=
@@ -98,7 +112,8 @@ def test_update_delete_and_move() -> None:
                 frequency: 2
               pad:
                 =before=: resample
-            """
+            """,
+            apply_ops=False,
         )
     )
 
@@ -118,15 +133,27 @@ def test_update_delete_and_move() -> None:
 @pytest.mark.parametrize(
     "update",
     [
-        {"steps": {"a": {ConfDict.BEFORE: "b", ConfDict.AFTER: "b"}}},
-        {"steps": {"a": {ConfDict.AFTER: "a"}}},
-        {"steps": {"a": {ConfDict.AFTER: "missing"}}},
+        {"steps": {"a": {ConfDict.ops.BEFORE: "b", ConfDict.ops.AFTER: "b"}}},
+        {"steps": {"a": {ConfDict.ops.AFTER: "a"}}},
+        {"steps": {"a": {ConfDict.ops.AFTER: "missing"}}},
     ],
 )
 def test_update_move_errors(update: dict[str, tp.Any]) -> None:
     data = ConfDict({"steps": {"a": {}, "b": {}}})
     with pytest.raises((KeyError, ValueError)):
         data.update(update)
+
+
+def test_update_rejects_unknown_ops() -> None:
+    data = ConfDict({"steps": {"a": {}}})
+    patch = ConfDict.from_yaml("steps:\n  =unknown=: a\n", apply_ops=False)
+    assert patch["steps.=unknown="] == "a"
+    with pytest.raises(ValueError, match="Unknown ConfDict op"):
+        data.update(patch)
+    with pytest.raises(ValueError, match="Unknown ConfDict op"):
+        data.update({"steps": {"a": "=unknown="}})
+    with pytest.raises(ValueError, match="Unexpected ConfDict op"):
+        data.update({"steps": {"a": ConfDict.ops.BEFORE}})
 
 
 @pytest.mark.parametrize(

--- a/exca/test_confdict.py
+++ b/exca/test_confdict.py
@@ -90,44 +90,131 @@ def test_update_ops_example() -> None:
 
 
 def test_update_delete_and_move() -> None:
-    data = ConfDict.from_yaml(
-        """
+    base = """
         steps:
           read.t: read
           clean.t: clean
           resample.t: resample
           pad.t: pad
         """
+    data = ConfDict.from_yaml(base)
+    patch = ConfDict.from_yaml(
+        """
+        steps:
+          clean: =delete=
+          project:
+            =after=: read
+            t: project
+          resample:
+            =after=: project
+            frequency: 2
+          pad:
+            =before=: resample
+        """
     )
-    data.update(
-        ConfDict.from_yaml(
-            """
-            steps:
-              clean: =delete=
-              project:
-                =after=: read
-                t: project
-              resample:
-                =after=: project
-                frequency: 2
-              pad:
-                =before=: resample
-            """,
-            apply_ops=False,
-        )
+    assert (
+        patch.to_yaml()
+        == """steps:
+  clean: =delete=
+  project:
+    =after=: read
+    t: project
+  pad: {}
+  resample.frequency: 2
+"""
     )
+
+    data.update(patch)
 
     assert (
         data.to_yaml()
         == """steps:
   read.t: read
   project.t: project
-  pad.t: pad
   resample:
     t: resample
     frequency: 2
+  pad.t: pad
 """
     )
+    data = ConfDict.from_yaml(base)
+    data.update(
+        ConfDict.from_yaml(
+            """
+            steps:
+              resample.t: resample
+              clean.t: clean
+            """
+        )
+    )
+    assert (
+        data.to_yaml()
+        == """steps:
+  read.t: read
+  clean.t: clean
+  resample.t: resample
+  pad.t: pad
+"""
+    )
+
+
+def test_update_keeps_deferred_ops_in_lists() -> None:
+    base = ConfDict({"item": {"name": "old", "size": 1}})
+    grid = ConfDict({"seed": [33]})
+
+    grid.update({"item": [{ConfDict.ops.REPLACE: True, "name": "new"}]})
+    element = grid.flat()["item"][0]
+    assert element == {ConfDict.ops.REPLACE: True, "name": "new"}
+
+    base.update({"item": element})
+    assert base["item"] == {"name": "new"}
+
+
+def test_update_moves_apply_eagerly() -> None:
+    data = ConfDict({"steps": {"a": {}, "b": {}, "c": {}}})
+
+    data.update(
+        {
+            "steps": {
+                "a": {ConfDict.ops.AFTER: "b"},
+                "b": {ConfDict.ops.AFTER: "c"},
+            }
+        }
+    )
+
+    assert list(data["steps"]) == ["a", "c", "b"]
+
+
+def test_update_keeps_move_when_anchor_is_added_later() -> None:
+    data = ConfDict({"steps": {"read": {}}})
+
+    data.update(
+        {
+            "steps": {
+                "resample": {ConfDict.ops.AFTER: "project"},
+                "project": {"t": "project"},
+            }
+        }
+    )
+
+    assert list(data["steps"]) == ["read", "resample", "project"]
+    assert data["steps.resample.=after="] == "project"
+
+
+def test_update_delete_happens_before_later_move() -> None:
+    data = ConfDict({"steps": {"a": {}, "c": {}, "b": {}}})
+
+    data.update(
+        {
+            "steps": {
+                "b": ConfDict.ops.DELETE,
+                "a": {ConfDict.ops.AFTER: "b"},
+            }
+        }
+    )
+
+    assert list(data["steps"]) == ["a", "c"]
+    assert data["steps.a.=after="] == "b"
 
 
 @pytest.mark.parametrize(
@@ -135,25 +222,22 @@ def test_update_delete_and_move() -> None:
     [
         {"steps": {"a": {ConfDict.ops.BEFORE: "b", ConfDict.ops.AFTER: "b"}}},
         {"steps": {"a": {ConfDict.ops.AFTER: "a"}}},
-        {"steps": {"a": {ConfDict.ops.AFTER: "missing"}}},
     ],
 )
 def test_update_move_errors(update: dict[str, tp.Any]) -> None:
     data = ConfDict({"steps": {"a": {}, "b": {}}})
-    with pytest.raises((KeyError, ValueError)):
+    with pytest.raises(ValueError):
         data.update(update)
 
 
 def test_update_rejects_unknown_ops() -> None:
     data = ConfDict({"steps": {"a": {}}})
-    patch = ConfDict.from_yaml("steps:\n  =unknown=: a\n", apply_ops=False)
-    assert patch["steps.=unknown="] == "a"
     with pytest.raises(ValueError, match="Unknown ConfDict op"):
-        data.update(patch)
+        ConfDict.from_yaml("steps:\n  =unknown=: a\n")
     with pytest.raises(ValueError, match="Unknown ConfDict op"):
         data.update({"steps": {"a": "=unknown="}})
-    with pytest.raises(ValueError, match="Unexpected ConfDict op"):
-        data.update({"steps": {"a": ConfDict.ops.BEFORE}})
+    data.update({"steps": {"a": ConfDict.ops.BEFORE}})
+    assert data["steps.a"] == ConfDict.ops.BEFORE
 
 
 @pytest.mark.parametrize(

--- a/exca/test_confdict.py
+++ b/exca/test_confdict.py
@@ -437,6 +437,15 @@ def test_uid_ordering_rules() -> None:
     )
 
 
+def test_update_preserves_ordered_dict_uid_order() -> None:
+    cfg = ConfDict({"x": OrderedDict((name, {"value": name}) for name in ("a", "b"))})
+    uid = cfg.to_uid()
+    cfg.update({"x": {"b": {ConfDict.ops.BEFORE: "a"}}})
+    assert isinstance(cfg["x"], OrderedDict)
+    assert list(cfg["x"]) == ["b", "a"]
+    assert cfg.to_uid() != uid
+
+
 def test_set_hash() -> None:
     data = [str(k) for k in range(6)]
     np.random.shuffle(data)

--- a/exca/test_confdict.py
+++ b/exca/test_confdict.py
@@ -172,6 +172,9 @@ item:
     data.update({"item": grid.flat()["item"][0]})
     assert data["item"] == {"name": "new"}
 
+    data.update({"item.name": ConfDict.ops.DELETE})
+    assert data["item"] == {}
+
 
 @pytest.mark.parametrize(
     "data",

--- a/exca/test_confdict.py
+++ b/exca/test_confdict.py
@@ -174,6 +174,20 @@ item:
 
 
 @pytest.mark.parametrize(
+    "data",
+    [
+        {"missing": ConfDict.ops.DELETE},
+        {"item": {ConfDict.ops.REPLACE: True, "name": "new"}},
+        {"item": {ConfDict.ops.BEFORE: "anchor"}},
+        {"item": {ConfDict.ops.AFTER: "anchor"}},
+    ],
+)
+def test_to_uid_rejects_unresolved_ops(data: dict[str, tp.Any]) -> None:
+    with pytest.raises(ValueError, match="unresolved config"):
+        ConfDict(data).to_uid()
+
+
+@pytest.mark.parametrize(
     "update",
     [
         {"steps": {"a": {ConfDict.ops.BEFORE: "b", ConfDict.ops.AFTER: "b"}}},

--- a/exca/test_confdict.py
+++ b/exca/test_confdict.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 import dataclasses
 import decimal
+import doctest
 import fractions
 import glob
 import typing as tp
@@ -79,14 +80,20 @@ def test_update() -> None:
     assert data == {"a": {"b": {"e": 15}, "c": 1}}
 
 
-def test_update_ops_example() -> None:
-    data = ConfDict({"a": {"x": 1}, "b": {"x": 2}})
-
-    data.update({"a": {ConfDict.ops.REPLACE: True, "y": 4}, "b": {"y": 12}})
-    assert data == {"a": {"y": 4}, "b": {"x": 2, "y": 12}}
-
-    data.update({"a": {ConfDict.ops.AFTER: "b"}, "b.x": ConfDict.ops.DELETE})
-    assert data == {"b": {"y": 12}, "a": {"y": 4}}
+def test_update_docstring_examples() -> None:
+    parser = doctest.DocTestParser()
+    runner = doctest.DocTestRunner()
+    docstring = ConfDict.update.__doc__
+    assert docstring is not None
+    test = parser.get_doctest(
+        docstring,
+        {"ConfDict": ConfDict},
+        "ConfDict.update",
+        None,
+        0,
+    )
+    result = runner.run(test)
+    assert not result.failed
 
 
 def test_update_delete_and_move() -> None:
@@ -96,6 +103,9 @@ def test_update_delete_and_move() -> None:
           clean.t: clean
           resample.t: resample
           pad.t: pad
+        item:
+          name: old
+          size: 1
         """
     data = ConfDict.from_yaml(base)
     patch = ConfDict.from_yaml(
@@ -110,6 +120,8 @@ def test_update_delete_and_move() -> None:
             frequency: 2
           pad:
             =before=: resample
+          late:
+            =after=: missing
         """
     )
     assert (
@@ -121,6 +133,7 @@ def test_update_delete_and_move() -> None:
     t: project
   pad: {}
   resample.frequency: 2
+  late.=after=: missing
 """
     )
 
@@ -135,95 +148,29 @@ def test_update_delete_and_move() -> None:
     t: resample
     frequency: 2
   pad.t: pad
+  late.=after=: missing
+item:
+  name: old
+  size: 1
 """
     )
-    data = ConfDict.from_yaml(base)
-    data.update(
-        ConfDict.from_yaml(
-            """
-            steps:
-              resample.t: resample
-              clean.t: clean
-            """
-        )
-    )
-    assert (
-        data.to_yaml()
-        == """steps:
-  read.t: read
-  clean.t: clean
-  resample.t: resample
-  pad.t: pad
-"""
-    )
-
-
-def test_update_keeps_deferred_ops_in_lists() -> None:
-    base = ConfDict({"item": {"name": "old", "size": 1}})
-    grid = ConfDict({"seed": [33]})
-
-    grid.update({"item": [{ConfDict.ops.REPLACE: True, "name": "new"}]})
-    element = grid.flat()["item"][0]
-    assert element == {ConfDict.ops.REPLACE: True, "name": "new"}
-
-    base.update({"item": element})
-    assert base["item"] == {"name": "new"}
-
-
-def test_update_moves_apply_eagerly() -> None:
-    data = ConfDict({"steps": {"a": {}, "b": {}, "c": {}}})
-
-    data.update(
-        {
-            "steps": {
-                "a": {ConfDict.ops.AFTER: "b"},
-                "b": {ConfDict.ops.AFTER: "c"},
-            }
-        }
-    )
-
-    assert list(data["steps"]) == ["a", "c", "b"]
-
-
-def test_update_delete_happens_before_later_move() -> None:
-    data = ConfDict({"steps": {"a": {}, "c": {}, "b": {}}})
-
-    data.update(
-        {
-            "steps": {
-                "b": ConfDict.ops.DELETE,
-                "a": {ConfDict.ops.AFTER: "b"},
-            }
-        }
-    )
-
-    assert list(data["steps"]) == ["a", "c"]
-    assert data["steps.a.=after="] == "b"
-
-
-def test_update_resolves_dangling_move_when_key_is_updated_again() -> None:
-    data = ConfDict({"steps": {"read": {}}})
-    data.update(
-        {
-            "steps": {
-                "resample": {ConfDict.ops.AFTER: "project"},
-                "project": {"t": "project"},
-            }
-        }
-    )
-
-    assert list(data["steps"]) == ["read", "resample", "project"]
-    assert data["steps.resample.=after="] == "project"
-
-    data.update({"steps": {"resample": {"t": 1}}})
-    assert list(data["steps"]) == ["read", "project", "resample"]
-    assert data["steps.resample"] == {"t": 1}
-
-
-def test_to_uid_rejects_unresolved_move() -> None:
-    data = ConfDict({"steps": {"read": {}, "resample": {ConfDict.ops.AFTER: "project"}}})
     with pytest.raises(ValueError, match="unresolved config"):
         data.to_uid()
+
+    data.update({"steps": {"missing": {}, "late": {"t": 1}}})
+    assert list(data["steps"]) == [
+        "read",
+        "project",
+        "resample",
+        "pad",
+        "missing",
+        "late",
+    ]
+    assert data["steps.late"] == {"t": 1}
+
+    grid = ConfDict({"item": [{ConfDict.ops.REPLACE: True, "name": "new"}]})
+    data.update({"item": grid.flat()["item"][0]})
+    assert data["item"] == {"name": "new"}
 
 
 @pytest.mark.parametrize(
@@ -234,28 +181,14 @@ def test_to_uid_rejects_unresolved_move() -> None:
         {"steps": {"a": ConfDict.ops.REPLACE}},
         {"steps": {"a": ConfDict.ops.BEFORE}},
         {"steps": {"a": ConfDict.ops.AFTER}},
+        {"steps": {"=unknown=": "a"}},
+        {"steps": {"a": "=unknown="}},
     ],
 )
 def test_update_op_errors(update: dict[str, tp.Any]) -> None:
     data = ConfDict({"steps": {"a": {}, "b": {}}})
     with pytest.raises(ValueError):
         data.update(update)
-
-
-def test_update_combines_replace_and_move() -> None:
-    data = ConfDict({"steps": {"a": {"x": 1}, "b": {}}})
-    update = {ConfDict.ops.REPLACE: True, ConfDict.ops.AFTER: "b", "z": 9}
-    data.update({"steps": {"a": update}})
-    assert list(data["steps"]) == ["b", "a"]
-    assert data["steps.a"] == {"z": 9}
-
-
-def test_update_rejects_unknown_ops() -> None:
-    data = ConfDict({"steps": {"a": {}}})
-    with pytest.raises(ValueError, match="Unknown ConfDict op"):
-        ConfDict.from_yaml("steps:\n  =unknown=: a\n")
-    with pytest.raises(ValueError, match="Unknown ConfDict op"):
-        data.update({"steps": {"a": "=unknown="}})
 
 
 @pytest.mark.parametrize(

--- a/exca/test_confdict.py
+++ b/exca/test_confdict.py
@@ -185,22 +185,6 @@ def test_update_moves_apply_eagerly() -> None:
     assert list(data["steps"]) == ["a", "c", "b"]
 
 
-def test_update_keeps_move_when_anchor_is_added_later() -> None:
-    data = ConfDict({"steps": {"read": {}}})
-
-    data.update(
-        {
-            "steps": {
-                "resample": {ConfDict.ops.AFTER: "project"},
-                "project": {"t": "project"},
-            }
-        }
-    )
-
-    assert list(data["steps"]) == ["read", "resample", "project"]
-    assert data["steps.resample.=after="] == "project"
-
-
 def test_update_delete_happens_before_later_move() -> None:
     data = ConfDict({"steps": {"a": {}, "c": {}, "b": {}}})
 
@@ -218,21 +202,26 @@ def test_update_delete_happens_before_later_move() -> None:
 
 
 def test_update_resolves_dangling_move_when_key_is_updated_again() -> None:
-    data = ConfDict({"steps": {"read": {}, "resample": {ConfDict.ops.AFTER: "project"}}})
-    assert list(data["steps"]) == ["read", "resample"], "anchor absent -> dangling"
+    data = ConfDict({"steps": {"read": {}}})
+    data.update(
+        {
+            "steps": {
+                "resample": {ConfDict.ops.AFTER: "project"},
+                "project": {"t": "project"},
+            }
+        }
+    )
 
-    # adding the anchor alone does not resolve it: resample must be merged again
-    data.update({"steps": {"project": {}}})
     assert list(data["steps"]) == ["read", "resample", "project"]
+    assert data["steps.resample.=after="] == "project"
 
     data.update({"steps": {"resample": {"t": 1}}})
     assert list(data["steps"]) == ["read", "project", "resample"]
-    assert data["steps.resample"] == {"t": 1}, "op consumed once applied"
+    assert data["steps.resample"] == {"t": 1}
 
 
 def test_to_uid_rejects_unresolved_move() -> None:
     data = ConfDict({"steps": {"read": {}, "resample": {ConfDict.ops.AFTER: "project"}}})
-    assert data.to_yaml()  # dangling ops stay renderable
     with pytest.raises(ValueError, match="unresolved config"):
         data.to_uid()
 
@@ -242,9 +231,12 @@ def test_to_uid_rejects_unresolved_move() -> None:
     [
         {"steps": {"a": {ConfDict.ops.BEFORE: "b", ConfDict.ops.AFTER: "b"}}},
         {"steps": {"a": {ConfDict.ops.AFTER: "a"}}},
+        {"steps": {"a": ConfDict.ops.REPLACE}},
+        {"steps": {"a": ConfDict.ops.BEFORE}},
+        {"steps": {"a": ConfDict.ops.AFTER}},
     ],
 )
-def test_update_move_errors(update: dict[str, tp.Any]) -> None:
+def test_update_op_errors(update: dict[str, tp.Any]) -> None:
     data = ConfDict({"steps": {"a": {}, "b": {}}})
     with pytest.raises(ValueError):
         data.update(update)
@@ -255,7 +247,7 @@ def test_update_combines_replace_and_move() -> None:
     update = {ConfDict.ops.REPLACE: True, ConfDict.ops.AFTER: "b", "z": 9}
     data.update({"steps": {"a": update}})
     assert list(data["steps"]) == ["b", "a"]
-    assert data["steps.a"] == {"z": 9}, "content replaced, then key moved"
+    assert data["steps.a"] == {"z": 9}
 
 
 def test_update_rejects_unknown_ops() -> None:
@@ -264,8 +256,6 @@ def test_update_rejects_unknown_ops() -> None:
         ConfDict.from_yaml("steps:\n  =unknown=: a\n")
     with pytest.raises(ValueError, match="Unknown ConfDict op"):
         data.update({"steps": {"a": "=unknown="}})
-    data.update({"steps": {"a": ConfDict.ops.BEFORE}})
-    assert data["steps.a"] == ConfDict.ops.BEFORE
 
 
 @pytest.mark.parametrize(

--- a/exca/test_confdict.py
+++ b/exca/test_confdict.py
@@ -208,6 +208,21 @@ def test_update_op_errors(update: dict[str, tp.Any]) -> None:
 
 
 @pytest.mark.parametrize(
+    "update",
+    [
+        {"steps": {"missing": "=unknown="}},
+        {"steps": {"=unknown=": "a"}},
+    ],
+)
+def test_update_op_error_does_not_mutate(update: dict[str, tp.Any]) -> None:
+    data = ConfDict({"steps": {"a": {}, "b": {}}})
+    before = data.to_yaml()
+    with pytest.raises(ValueError):
+        data.update(update)
+    assert data.to_yaml() == before
+
+
+@pytest.mark.parametrize(
     "update,expected",
     [
         ({"a.b.c": 12}, {"a.b.c": 12}),

--- a/exca/test_helpers.py
+++ b/exca/test_helpers.py
@@ -109,8 +109,8 @@ def test_discriminated_model() -> None:
     model = Model(sub={"name": "World", "string": "Hello"})  # type: ignore
     cfg = ConfDict.from_model(model, exclude_defaults=True, uid=True)
     expected = """sub:
-  name: World
   string: Hello
+  name: World
 """
     assert cfg.to_yaml() == expected
     # instantiate base

--- a/exca/test_helpers.py
+++ b/exca/test_helpers.py
@@ -109,8 +109,8 @@ def test_discriminated_model() -> None:
     model = Model(sub={"name": "World", "string": "Hello"})  # type: ignore
     cfg = ConfDict.from_model(model, exclude_defaults=True, uid=True)
     expected = """sub:
-  string: Hello
   name: World
+  string: Hello
 """
     assert cfg.to_yaml() == expected
     # instantiate base

--- a/exca/test_utils.py
+++ b/exca/test_utils.py
@@ -119,12 +119,12 @@ def test_discriminators(caplog: tp.Any) -> None:
         seq=[[{"uid": "D2"}, {"uid": "D1"}]],  # type: ignore
     )
     expected = """inst.uid: D2
+something_else: 12
 seq:
 - - uid: D2
-  - anything: 12
+  - uid: D1
+    anything: 12
     sub.uid: D2
-    uid: D1
-something_else: 12
 stuff: []
 """
     # check uid of subinstance (should not have discriminator)
@@ -134,10 +134,10 @@ stuff: []
     out = ConfDict.from_model(d).to_yaml()
     assert out == expected
     expected = """inst.uid: D2
+something_else: 12
 seq:
 - - uid: D2
   - uid: D1
-something_else: 12
 """
     out = ConfDict.from_model(d, exclude_defaults=True).to_yaml()
     assert not caplog.records

--- a/exca/test_utils.py
+++ b/exca/test_utils.py
@@ -14,10 +14,11 @@ from pathlib import Path
 
 import pydantic
 import pytest
+import yaml
 
 import exca
 
-from . import utils
+from . import steps, utils
 from .confdict import ConfDict
 from .utils import ShortItemUid, to_dict
 
@@ -585,6 +586,26 @@ def test_check_configs(tmp_path: Path) -> None:
     utils.ConfigDump(model=models).check_and_write(folder2)
     content = (folder2 / "uid.yaml").read_text("utf8")
     assert content == "- x: 1\n- x: 2\n"
+
+
+class OrderYamlStep(steps.Step):
+    b: int = 2
+    a: int = 1
+
+    def _run(self, value: int = 0) -> int:
+        return value + self.a + self.b
+
+
+def test_check_configs_accepts_uid_yaml_key_order_change(tmp_path: Path) -> None:
+    step = OrderYamlStep(a=3, b=5, infra=steps.backends.Cached(folder=tmp_path))
+    assert step.run() == 8
+
+    uid_file = step.lookup().paths.step_folder / "uid.yaml"
+    current = uid_file.read_text("utf8")
+    uid_file.write_text(yaml.safe_dump(yaml.safe_load(current), sort_keys=True))
+    assert uid_file.read_text("utf8") != current
+
+    assert step.clone().run() == 8
 
 
 def test_check_configs_concurrently(tmp_path: Path) -> None:

--- a/exca/utils.py
+++ b/exca/utils.py
@@ -704,7 +704,7 @@ class ConfigDump:
         data = getattr(self, name.replace("-", "_"))
         if hasattr(data, "to_yaml"):
             return data.to_yaml()  # ConfDict with OrderedDict support
-        return _yaml.safe_dump(data, sort_keys=True)
+        return _yaml.safe_dump(data, sort_keys=False)
 
     def _error(self, msg: str) -> RuntimeError:
         return RuntimeError(f"{msg}\n\n(this is for object: {self.model!r})")
@@ -739,16 +739,23 @@ class ConfigDump:
                 corrupted.add(name)
                 return None
 
-        # uid.yaml must match exactly (cache collision detection)
+        # uid.yaml must match (cache collision detection)
         prev_uid = read_file("uid")
         curr_uid = self._to_yaml("uid")
         if prev_uid is not None and curr_uid != prev_uid:
-            diff = "\n".join(difflib.ndiff(curr_uid.splitlines(), prev_uid.splitlines()))
-            uid_str = as_confdict(self.uid).to_uid()
-            raise self._error(
-                f"Inconsistent uid config for {uid_str} in '{folder / 'uid.yaml'}':\n"
-                f"* got:\n{curr_uid!r}\n\n* but uid file contains:\n{prev_uid!r}\n\n(diff:\n{diff})"
-            )
+            sorted_uids = [  # ordering may differ (support convention change)
+                _yaml.safe_dump(_yaml.safe_load(uid), sort_keys=True)
+                for uid in (prev_uid, curr_uid)
+            ]
+            if sorted_uids[0] != sorted_uids[1]:
+                uid_str = as_confdict(self.uid).to_uid()
+                diff = "\n".join(
+                    difflib.ndiff(curr_uid.splitlines(), prev_uid.splitlines())
+                )
+                raise self._error(
+                    f"Inconsistent uid config for {uid_str} in '{folder / 'uid.yaml'}':\n"
+                    f"* got:\n{curr_uid!r}\n\n* but uid file contains:\n{prev_uid!r}\n\n(diff:\n{diff})"
+                )
 
         # Check full-uid for incompatible default changes
         prev_full = read_file("full-uid")


### PR DESCRIPTION
- Added operations `ConfDict.ops.DELETE`, `ConfDict.ops.BEFORE`, and `ConfDict.ops.AFTER`; `ConfDict.ops.REPLACE` replaces `ConfDict.OVERRIDE`.
- `ConfDict` patches apply top to bottom: mapping entries merge content, then move if their anchor exists; unresolved ops remain visible.
- UID generation rejects unresolved `ConfDict` ops to avoid cache keys from incomplete configs.
- Config YAML dumps preserve key order, while cache `uid.yaml` checks tolerate key-order-only changes for compatibility.
- Discriminator fields serialize first for more stable/readable config YAML.
