### PR TITLE
Chmod intermediate uid_folder() directories, not just root and leaf

### DIFF
--- a/exca/base.py
+++ b/exca/base.py
@@ -346,7 +346,7 @@ class BaseInfra(pydantic.BaseModel):
         folder = Path(self.folder) / self.uid()
         if not create:
             return folder
-        utils._mkdir_with_permissions(folder, self.permissions, root=self.folder)
+        utils.mkdir_with_permissions(folder, self.permissions, root=self.folder)
         return folder
 
     def iter_cached(self) -> tp.Iterable[pydantic.BaseModel]:

--- a/exca/base.py
+++ b/exca/base.py
@@ -131,7 +131,7 @@ class BaseInfra(pydantic.BaseModel):
     # general permission for folders and files
     # use os.chmod / path.chmod compatible numbers, or None to deactivate
     # eg: 0o777 for all rights to all users
-    permissions: int | str | None = 0o777
+    permissions: int | None = 0o777
     # {folder} will be replaced by the class folder
     # {user} by user id and %j by job id
     logs: Path | str = "{folder}/logs/{user}/%j"
@@ -195,8 +195,8 @@ class BaseInfra(pydantic.BaseModel):
         return list(set(type(self).model_fields) - {"version"})
 
     def model_post_init(self, log__: tp.Any) -> None:
+        # Pydantic's private-attr hook would otherwise shadow SubmititMixin's hook.
         super().model_post_init(log__)
-        self._set_permissions(None)  # set compatibility for permissions as string
 
     def __repr_args__(self) -> tp.Iterator[tuple[str | None, tp.Any]]:
         """Compact repr: only show fields that differ from their default value."""
@@ -346,14 +346,7 @@ class BaseInfra(pydantic.BaseModel):
         folder = Path(self.folder) / self.uid()
         if not create:
             return folder
-        folder.mkdir(exist_ok=True, parents=True)
-        self._set_permissions(self.folder)
-        # the uid can contain several "/" segments (e.g. "{method},{version}/{uid}"),
-        # so mkdir(parents=True) may create intermediate directories in between
-        # self.folder and folder; chmod those too, not just the two endpoints.
-        for parent in reversed(list(folder.relative_to(self.folder).parents)[:-1]):
-            self._set_permissions(self.folder / parent)
-        self._set_permissions(folder)
+        utils._mkdir_with_permissions(folder, self.permissions, root=self.folder)
         return folder
 
     def iter_cached(self) -> tp.Iterable[pydantic.BaseModel]:
@@ -369,17 +362,8 @@ class BaseInfra(pydantic.BaseModel):
             cfg = ConfDict.from_yaml(fp)
             yield cls(**cfg)
 
-    def _set_permissions(self, path: str | Path | None) -> None:
-        if isinstance(self.permissions, str):
-            if not self.permissions:
-                self.permissions = None
-            elif self.permissions == "a+rwx":
-                self.permissions = 0o777
-            else:
-                raise ValueError(f"No compatibility for permissions {self.permissions}")
-            msg = "infra.permissions set to %s by compatibility mode"
-            logger.warning(msg, self.permissions)
-        if path is not None and self.permissions is not None:
+    def _set_permissions(self, path: str | Path) -> None:
+        if self.permissions is not None:
             try:
                 Path(path).chmod(self.permissions)
             except Exception as e:

--- a/exca/base.py
+++ b/exca/base.py
@@ -348,6 +348,11 @@ class BaseInfra(pydantic.BaseModel):
             return folder
         folder.mkdir(exist_ok=True, parents=True)
         self._set_permissions(self.folder)
+        # the uid can contain several "/" segments (e.g. "{method},{version}/{uid}"),
+        # so mkdir(parents=True) may create intermediate directories in between
+        # self.folder and folder; chmod those too, not just the two endpoints.
+        for parent in reversed(list(folder.relative_to(self.folder).parents)[:-1]):
+            self._set_permissions(self.folder / parent)
         self._set_permissions(folder)
         return folder
 

--- a/exca/map.py
+++ b/exca/map.py
@@ -167,10 +167,6 @@ class MapInfra(base.BaseInfra, slurm.SubmititMixin):
             raise RuntimeError(f"Infra was not applied: {self!r}")
         cache_type = imethod.cache_type
         cache_path = self.uid_folder(create=True)
-        if isinstance(self.permissions, str):
-            self._set_permissions(None)
-        if isinstance(self.permissions, str):
-            raise RuntimeError("infra.permissions should have been an integer")
         cd: CacheDict[tp.Any] = CacheDict(
             folder=cache_path,
             keep_in_ram=self.keep_in_ram,
@@ -184,8 +180,7 @@ class MapInfra(base.BaseInfra, slurm.SubmititMixin):
         cache_folder = self.uid_folder()
         if cache_folder is None:
             return None
-        perm = self.permissions if isinstance(self.permissions, int) else None
-        return inflight.InflightRegistry(cache_folder, permissions=perm)
+        return inflight.InflightRegistry(cache_folder, permissions=self.permissions)
 
     # pylint: disable=unused-argument
     def apply(

--- a/exca/steps/base.py
+++ b/exca/steps/base.py
@@ -18,7 +18,7 @@ import warnings
 import pydantic
 
 import exca
-from exca import utils as exca_utils
+from exca import utils as xkutils
 
 from . import backends, identity, items, utils
 
@@ -295,9 +295,7 @@ class Step(exca.helpers.DiscriminatedModel):
             identity.step_uid(aligned),
             cache_type=self._infer_cache_type(),
         )
-        exca_utils._mkdir_with_permissions(
-            paths.step_folder, 0o777, root=paths.base_folder
-        )
+        xkutils.mkdir_with_permissions(paths.step_folder, 0o777, root=paths.base_folder)
         return paths
 
     def _exca_uid_dict_override(self) -> dict[str, tp.Any] | None:

--- a/exca/steps/base.py
+++ b/exca/steps/base.py
@@ -18,6 +18,7 @@ import warnings
 import pydantic
 
 import exca
+from exca import utils as exca_utils
 
 from . import backends, identity, items, utils
 
@@ -294,7 +295,9 @@ class Step(exca.helpers.DiscriminatedModel):
             identity.step_uid(aligned),
             cache_type=self._infer_cache_type(),
         )
-        paths.step_folder.mkdir(parents=True, exist_ok=True)
+        exca_utils._mkdir_with_permissions(
+            paths.step_folder, 0o777, root=paths.base_folder
+        )
         return paths
 
     def _exca_uid_dict_override(self) -> dict[str, tp.Any] | None:

--- a/exca/steps/test_backends.py
+++ b/exca/steps/test_backends.py
@@ -8,6 +8,7 @@
 
 import contextlib
 import logging
+import stat
 import sys
 import time
 import typing as tp
@@ -65,6 +66,16 @@ def test_backend_execution(tmp_path: Path, backend: str) -> None:
     assert out1 == out2
     job = chain.lookup(1).job()
     assert (job is not None) == (backend == "LocalProcess")
+
+
+def test_step_permissions(tmp_path: Path) -> None:
+    infra: tp.Any = {"backend": "Cached", "folder": tmp_path}
+    chain = Chain(steps=[conftest.Mult(coeff=2), conftest.Add(value=1)], infra=infra)
+    intermediate = chain.lookup(1).paths.step_folder.parent
+    intermediate.mkdir(parents=True)
+    intermediate.chmod(0o700)
+    chain.run(1)
+    assert stat.S_IMODE(intermediate.stat().st_mode) == 0o777
 
 
 def test_slurm_backend_param_forwarding(

--- a/exca/test_map.py
+++ b/exca/test_map.py
@@ -157,17 +157,6 @@ def test_find_slurm_job(tmp_path: Path) -> None:
     assert job.uid_config == {"param1": 13}
 
 
-def test_map_infra_perm(tmp_path: Path) -> None:
-    whatever = Whatever(infra={"folder": tmp_path, "permissions": 0o777})  # type: ignore
-    xpfold = whatever.infra.uid_folder()
-    assert xpfold is not None
-    xpfold.mkdir(parents=True)
-    before = xpfold.stat().st_mode
-    _ = list(whatever.process([1, 2, 2, 3]))
-    after = xpfold.stat().st_mode
-    assert after > before
-
-
 def test_map_infra_debug(tmp_path: Path) -> None:
     whatever = Whatever(infra={"folder": tmp_path, "cluster": "debug"})  # type: ignore
     _ = list(whatever.process([1, 2, 2, 3]))

--- a/exca/test_task.py
+++ b/exca/test_task.py
@@ -451,7 +451,7 @@ def test_uid_folder_permissions(tmp_path: Path) -> None:
 def test_uid_folder_rejects_escape(tmp_path: Path) -> None:
     infra: tp.Any = {"folder": tmp_path / "cache", "version": "x/../../escape"}
     whatever = Whatever(param1=13, infra1=infra)
-    with pytest.raises(ValueError, match="resolves outside"):
+    with pytest.raises(ValueError, match="must not contain"):
         whatever.infra1.uid_folder(create=True)
     assert not (tmp_path / "escape").exists()
 

--- a/exca/test_task.py
+++ b/exca/test_task.py
@@ -7,8 +7,10 @@
 import contextlib
 import importlib
 import logging
+import os
 import pickle
 import shutil
+import stat
 import sys
 import typing as tp
 import uuid
@@ -444,6 +446,30 @@ def test_permissions(tmp_path: Path) -> None:
     infra._set_permissions(fp)
     after = fp.stat().st_mode
     assert after > before
+
+
+def test_permissions_intermediate_uid_folder_dirs(tmp_path: Path) -> None:
+    """uid_folder() must chmod every directory mkdir(parents=True) creates.
+
+    The uid is formatted as "{method},{version}/{uid}" (see `_uid_string`), so
+    a fresh cache root has a "method,version" intermediate directory between
+    `infra.folder` and the leaf uid folder. Only the root and the leaf used to
+    be chmod-ed, leaving that intermediate directory at the umask-reduced mode.
+    """
+    old_umask = os.umask(0o022)
+    try:
+        whatever = Whatever(
+            param1=13, infra1={"folder": tmp_path, "permissions": 0o777}  # type: ignore
+        )
+        xpfolder = whatever.infra1.uid_folder(create=True)
+        assert xpfolder is not None
+        intermediate = xpfolder.parent
+        assert intermediate != tmp_path, "test assumes a nested uid with a '/' segment"
+        for path in (tmp_path, intermediate, xpfolder):
+            mode = stat.S_IMODE(path.stat().st_mode)
+            assert mode == 0o777, f"{path} has mode {oct(mode)}, expected 0o777"
+    finally:
+        os.umask(old_umask)
 
 
 class D2(pydantic.BaseModel):

--- a/exca/test_task.py
+++ b/exca/test_task.py
@@ -7,7 +7,6 @@
 import contextlib
 import importlib
 import logging
-import os
 import pickle
 import shutil
 import stat
@@ -437,39 +436,24 @@ def test_changing_defaults(tmp_path: Path) -> None:
         _ = whenever.process()
 
 
-def test_permissions(tmp_path: Path) -> None:
-    infra = Whatever(infra1={"permissions": "a+rwx"}).infra1  # type: ignore
-    fp = tmp_path / "test" / "whatever" / "text.txt"
-    fp.parent.mkdir(parents=True)
-    fp.touch()
-    before = fp.stat().st_mode
-    infra._set_permissions(fp)
-    after = fp.stat().st_mode
-    assert after > before
+def test_uid_folder_permissions(tmp_path: Path) -> None:
+    infra: tp.Any = {"folder": tmp_path}
+    whatever = Whatever(param1=13, infra1=infra)
+    uid_folder = whatever.infra1.uid_folder()
+    assert uid_folder is not None
+    intermediate = uid_folder.parent
+    intermediate.mkdir(parents=True)
+    intermediate.chmod(0o700)
+    whatever.infra1.uid_folder(create=True)
+    assert stat.S_IMODE(intermediate.stat().st_mode) == 0o777
 
 
-def test_permissions_intermediate_uid_folder_dirs(tmp_path: Path) -> None:
-    """uid_folder() must chmod every directory mkdir(parents=True) creates.
-
-    The uid is formatted as "{method},{version}/{uid}" (see `_uid_string`), so
-    a fresh cache root has a "method,version" intermediate directory between
-    `infra.folder` and the leaf uid folder. Only the root and the leaf used to
-    be chmod-ed, leaving that intermediate directory at the umask-reduced mode.
-    """
-    old_umask = os.umask(0o022)
-    try:
-        whatever = Whatever(
-            param1=13, infra1={"folder": tmp_path, "permissions": 0o777}  # type: ignore
-        )
-        xpfolder = whatever.infra1.uid_folder(create=True)
-        assert xpfolder is not None
-        intermediate = xpfolder.parent
-        assert intermediate != tmp_path, "test assumes a nested uid with a '/' segment"
-        for path in (tmp_path, intermediate, xpfolder):
-            mode = stat.S_IMODE(path.stat().st_mode)
-            assert mode == 0o777, f"{path} has mode {oct(mode)}, expected 0o777"
-    finally:
-        os.umask(old_umask)
+def test_uid_folder_rejects_escape(tmp_path: Path) -> None:
+    infra: tp.Any = {"folder": tmp_path / "cache", "version": "x/../../escape"}
+    whatever = Whatever(param1=13, infra1=infra)
+    with pytest.raises(ValueError, match="resolves outside"):
+        whatever.infra1.uid_folder(create=True)
+    assert not (tmp_path / "escape").exists()
 
 
 class D2(pydantic.BaseModel):

--- a/exca/utils.py
+++ b/exca/utils.py
@@ -52,7 +52,7 @@ def best_effort_utime(folder: Path) -> None:
             pass
 
 
-def _mkdir_with_permissions(
+def mkdir_with_permissions(
     folder: Path | str,
     permissions: int | None,
     *,

--- a/exca/utils.py
+++ b/exca/utils.py
@@ -59,30 +59,24 @@ def mkdir_with_permissions(
     root: Path | str,
 ) -> None:
     """Create a folder and chmod its directory chain within a root."""
-    root_path = Path(root).expanduser().resolve()
-    folder_path = Path(folder).expanduser().resolve()
-    if not folder_path.is_relative_to(root_path):
-        raise ValueError(
-            f"Folder {folder!s} resolves outside its permission root {root!s}"
-        )
+    root_path = Path(root)
+    folder_path = Path(folder)
+    parts = folder_path.relative_to(root_path).parts
+    if ".." in parts:
+        raise ValueError(f"Folder path must not contain '..': {folder}")
     folder_path.mkdir(parents=True, exist_ok=True)
     if permissions is None:
         return
     path = root_path
-    paths = [path]
-    for part in folder_path.relative_to(root_path).parts:
-        path /= part
-        paths.append(path)
-    for path in paths:
-        try:
+    try:
+        path.chmod(permissions)
+        for part in parts:
+            path /= part
             path.chmod(permissions)
-        except Exception as e:
-            logger.warning(
-                "Failed to set permission to %s on '%s'\n(%s)",
-                permissions,
-                path,
-                e,
-            )
+    except Exception as e:
+        logger.warning(
+            "Failed to set permission to %s on '%s'\n(%s)", permissions, path, e
+        )
 
 
 def to_chunks(

--- a/exca/utils.py
+++ b/exca/utils.py
@@ -52,6 +52,39 @@ def best_effort_utime(folder: Path) -> None:
             pass
 
 
+def _mkdir_with_permissions(
+    folder: Path | str,
+    permissions: int | None,
+    *,
+    root: Path | str,
+) -> None:
+    """Create a folder and chmod its directory chain within a root."""
+    root_path = Path(root).expanduser().resolve()
+    folder_path = Path(folder).expanduser().resolve()
+    if not folder_path.is_relative_to(root_path):
+        raise ValueError(
+            f"Folder {folder!s} resolves outside its permission root {root!s}"
+        )
+    folder_path.mkdir(parents=True, exist_ok=True)
+    if permissions is None:
+        return
+    path = root_path
+    paths = [path]
+    for part in folder_path.relative_to(root_path).parts:
+        path /= part
+        paths.append(path)
+    for path in paths:
+        try:
+            path.chmod(permissions)
+        except Exception as e:
+            logger.warning(
+                "Failed to set permission to %s on '%s'\n(%s)",
+                permissions,
+                path,
+                e,
+            )
+
+
 def to_chunks(
     items: list[X], *, max_chunks: int | None, min_items_per_chunk: int = 1
 ) -> list[list[X]]:


### PR DESCRIPTION
## Summary

`TaskInfra.uid_folder()` chmods only `self.folder` (the cache root) and the
leaf uid folder after `folder.mkdir(exist_ok=True, parents=True)`. Since the
uid is formatted as `"{method},{version}/{uid}"` (see `_uid_string`), a fresh
cache tree has at least one intermediate `"method,version"` directory created
by `mkdir(parents=True)` that was never chmod-ed and stays at the
umask-reduced default mode.

For neuralreport where we are sharing a cache, this blocks a second user from
writing into that intermediate directory, even though the root and leaf both
correctly show `0o777`.

## Where

`exca/base.py`, `TaskInfra.uid_folder()`:

```python
def uid_folder(self, create: bool = False) -> Path | None:
    """Folder where this task instance is stored"""
    if self.folder is None:
        return None
    folder = Path(self.folder) / self.uid()
    if not create:
        return folder
    folder.mkdir(exist_ok=True, parents=True)
    self._set_permissions(self.folder)
    self._set_permissions(folder)
    return folder
```

## Fix

Chmod every path component `mkdir(parents=True)` creates, not just the two
endpoints:

```python
folder.mkdir(exist_ok=True, parents=True)
self._set_permissions(self.folder)
for parent in reversed(list(folder.relative_to(self.folder).parents)[:-1]):
    self._set_permissions(self.folder / parent)
self._set_permissions(folder)
```

## Test

Added `test_permissions_intermediate_uid_folder_dirs` in `exca/test_task.py`:
builds a `Whatever` task with `permissions=0o777` under a restrictive umask
(`0o022`), calls `uid_folder(create=True)`, and asserts the root, the
intermediate `"method,version"` directory, and the leaf are all `0o777`.
Verified it fails (intermediate dir at `0o755`) without the fix and passes
with it.

## Validation

Ran the scoped suite (`test_task.py`, `test_base.py`, `test_map.py`,
`cachedict/`, `steps/`) both with and without the fix; the same pre-existing
failures occur in both (an mne/numba caching collection error and a couple of
environment-dependent slurm/submitit tests), so the fix introduces no
regressions.

## Possibly related (not fixed here, kept out of scope)

The same `mkdir(parents=True, exist_ok=True)` + leaf-only `_set_permissions`
pattern appears for the SLURM `executor.folder` in `exca/task.py` (around the
`executor.folder.mkdir(...)` call sites), so it may be worth auditing
separately.
